### PR TITLE
Everything

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -168,6 +168,4 @@ void HostDispatchJobs();
 
 void DoFrameStep();
 
-void UpdateInputGate(bool require_focus, bool require_full_focus = false);
-
 }  // namespace Core

--- a/Source/Core/Core/FreeLookManager.h
+++ b/Source/Core/Core/FreeLookManager.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <optional>
 
 #include "Common/CommonTypes.h"
@@ -59,5 +58,4 @@ private:
   ControllerEmu::IMUGyroscope* m_rotation_gyro;
 
   const unsigned int m_index;
-  std::optional<std::chrono::steady_clock::time_point> m_last_free_look_rotate_time;
 };

--- a/Source/Core/Core/HW/GCKeyboardEmu.cpp
+++ b/Source/Core/Core/HW/GCKeyboardEmu.cpp
@@ -108,9 +108,9 @@ ControllerEmu::ControlGroup* GCKeyboard::GetGroup(KeyboardGroup group)
   }
 }
 
-KeyboardStatus GCKeyboard::GetInput() const
+KeyboardStatus GCKeyboard::GetInput()
 {
-  const auto lock = GetStateLock();
+  CacheInputAndRefreshOutput();
 
   KeyboardStatus kb = {};
 
@@ -127,6 +127,8 @@ KeyboardStatus GCKeyboard::GetInput() const
 void GCKeyboard::LoadDefaults(const ControllerInterface& ciface)
 {
   EmulatedController::LoadDefaults(ciface);
+
+  const auto lock = GetStateLock();
 
   // Buttons
   m_keys0x->SetControlExpression(5, "A");

--- a/Source/Core/Core/HW/GCKeyboardEmu.h
+++ b/Source/Core/Core/HW/GCKeyboardEmu.h
@@ -31,7 +31,7 @@ class GCKeyboard : public ControllerEmu::EmulatedController
 {
 public:
   explicit GCKeyboard(unsigned int index);
-  KeyboardStatus GetInput() const;
+  KeyboardStatus GetInput();
   std::string GetName() const override;
   ControllerEmu::ControlGroup* GetGroup(KeyboardGroup group);
   void LoadDefaults(const ControllerInterface& ciface) override;

--- a/Source/Core/Core/HW/GCPad.cpp
+++ b/Source/Core/Core/HW/GCPad.cpp
@@ -66,11 +66,6 @@ void Rumble(const int pad_num, const ControlState strength)
   static_cast<GCPad*>(s_config.GetController(pad_num))->SetOutput(strength);
 }
 
-void ResetRumble(const int pad_num)
-{
-  static_cast<GCPad*>(s_config.GetController(pad_num))->SetOutput(0.0);
-}
-
 bool GetMicButton(const int pad_num)
 {
   return static_cast<GCPad*>(s_config.GetController(pad_num))->GetMicButton();

--- a/Source/Core/Core/HW/GCPad.h
+++ b/Source/Core/Core/HW/GCPad.h
@@ -27,7 +27,6 @@ InputConfig* GetConfig();
 GCPadStatus GetStatus(int pad_num);
 ControllerEmu::ControlGroup* GetGroup(int pad_num, PadGroup group);
 void Rumble(int pad_num, ControlState strength);
-void ResetRumble(int pad_num);
 
 bool GetMicButton(int pad_num);
 }  // namespace Pad

--- a/Source/Core/Core/HW/GCPadEmu.h
+++ b/Source/Core/Core/HW/GCPadEmu.h
@@ -34,7 +34,7 @@ class GCPad : public ControllerEmu::EmulatedController
 {
 public:
   explicit GCPad(unsigned int index);
-  GCPadStatus GetInput() const;
+  GCPadStatus GetInput();
   void SetOutput(const ControlState strength);
 
   bool GetMicButton() const;

--- a/Source/Core/Core/HW/SI/SI.h
+++ b/Source/Core/Core/HW/SI/SI.h
@@ -33,7 +33,7 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
 void ScheduleEvent(int device_number, s64 cycles_into_future, u64 userdata = 0);
 void RemoveEvent(int device_number);
 
-void UpdateDevices();
+void UpdateDevices(double delta_seconds, double average_delta_seconds);
 
 void RemoveDevice(int device_number);
 void AddDevice(SIDevices device, int device_number);

--- a/Source/Core/Core/HW/VideoInterface.cpp
+++ b/Source/Core/Core/HW/VideoInterface.cpp
@@ -70,8 +70,10 @@ static constexpr std::array<u32, 2> s_clock_freqs{{
 
 static u64 s_ticks_last_line_start;  // number of ticks when the current full scanline started
 static u32 s_half_line_count;        // number of halflines that have occurred for this full frame
-static u32 s_half_line_of_next_si_poll;  // halfline when next SI poll results should be available
-static constexpr u32 num_half_lines_for_si_poll = (7 * 2) + 1;  // this is how long an SI poll takes
+static u32 s_half_line_of_next_si_poll;   // halfline when next SI poll results should be available
+static u64 s_prev_si_poll_ticks;          // number of ticks at the last SI poll
+static double s_prev_si_poll_delta_time;  // delta time between the last two SI polls
+static constexpr u32 num_half_lines_for_si_poll = (7 * 2) + 1;  // this is how long a SI poll takes
 
 // below indexes are 0-based
 static u32 s_even_field_first_hl;  // index first halfline of the even field
@@ -105,6 +107,8 @@ void DoState(PointerWrap& p)
   p.Do(m_BorderHBlank);
   p.Do(s_ticks_last_line_start);
   p.Do(s_half_line_count);
+  p.Do(s_prev_si_poll_ticks);
+  p.Do(s_prev_si_poll_delta_time);
   p.Do(s_half_line_of_next_si_poll);
 
   UpdateParameters();
@@ -188,6 +192,8 @@ void Preset(bool _bNTSC)
 
   s_ticks_last_line_start = 0;
   s_half_line_count = 0;
+  s_prev_si_poll_ticks = 0;
+  s_prev_si_poll_delta_time = 0.0;
   s_half_line_of_next_si_poll = num_half_lines_for_si_poll;  // first sampling starts at vsync
 
   UpdateParameters();
@@ -866,9 +872,18 @@ void Update(u64 ticks)
 
   if (s_half_line_of_next_si_poll == s_half_line_count)
   {
-    Core::UpdateInputGate(!SConfig::GetInstance().m_BackgroundInput,
-                          SConfig::GetInstance().bLockCursor);
-    SerialInterface::UpdateDevices();
+    double delta_time =
+        double(CoreTiming::GetTicks() - s_prev_si_poll_ticks) / SystemTimers::GetTicksPerSecond();
+    // Clamp just to be sure our values won't be extremely high in the first frame or when
+    // switching between GC and Wii.
+    delta_time = std::min(delta_time, 1.0 / VideoInterface::GetTargetRefreshRate());
+    s_prev_si_poll_ticks = CoreTiming::GetTicks();
+
+    // Input delta time will average itself to the video refresh rate every two updates.
+    // Ignore cases where s_prev_si_poll_delta_time might be 0 or "wrong" as it likely won't matter.
+    SerialInterface::UpdateDevices(delta_time, (delta_time + s_prev_si_poll_delta_time) / 2.0);
+    s_prev_si_poll_delta_time = delta_time;
+
     s_half_line_of_next_si_poll += 2 * SerialInterface::GetPollXLines();
   }
 

--- a/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Dynamics.cpp
@@ -227,7 +227,7 @@ WiimoteCommon::AccelData ConvertAccelData(const Common::Vec3& accel, u16 zero_g,
 
 void EmulatePoint(MotionState* state, ControllerEmu::Cursor* ir_group, float time_elapsed)
 {
-  const auto cursor = ir_group->GetState(true);
+  const auto cursor = ir_group->GetState(false, time_elapsed);
 
   if (!cursor.IsVisible())
   {
@@ -310,7 +310,7 @@ void EmulateIMUCursor(IMUCursorState* state, ControllerEmu::IMUCursor* imu_ir_gr
                       ControllerEmu::IMUAccelerometer* imu_accelerometer_group,
                       ControllerEmu::IMUGyroscope* imu_gyroscope_group, float time_elapsed)
 {
-  const auto ang_vel = imu_gyroscope_group->GetState();
+  const auto ang_vel = imu_gyroscope_group->GetState(true);
 
   // Reset if pointing is disabled or we have no gyro data.
   if (!imu_ir_group->enabled || !ang_vel.has_value())

--- a/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Extension/Nunchuk.cpp
@@ -185,6 +185,8 @@ void Nunchuk::DoState(PointerWrap& p)
 
 void Nunchuk::LoadDefaults(const ControllerInterface& ciface)
 {
+  // Super::LoadDefaults() isn't needed. GetStateLock() is already called the parent Wiimote.
+
   // Stick
   m_stick->SetControlExpression(0, "W");  // up
   m_stick->SetControlExpression(1, "S");  // down

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -13,6 +13,7 @@
 #include "Common/MsgHandler.h"
 #include "Common/NandPaths.h"
 #include "Common/StringUtil.h"
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Debugger/Debugger_SymbolMap.h"
@@ -22,6 +23,7 @@
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
 #include "Core/SysConf.h"
+#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace IOS::HLE
@@ -336,10 +338,12 @@ void BluetoothEmuDevice::Update()
   const u64 interval = SystemTimers::GetTicksPerSecond() / Wiimote::UPDATE_FREQ;
   const u64 now = CoreTiming::GetTicks();
 
-  if (now - m_last_ticks > interval)
+  if (now - m_last_ticks >= interval)
   {
-    g_controller_interface.SetCurrentInputChannel(ciface::InputChannel::Bluetooth);
-    g_controller_interface.UpdateInput();
+    g_controller_interface.UpdateInput(ciface::InputChannel::Bluetooth, 1.0 / Wiimote::UPDATE_FREQ);
+    ControlReference::UpdateGate(!SConfig::GetInstance().m_BackgroundInput,
+                                 SConfig::GetInstance().bLockCursor, true,
+                                 ciface::InputChannel::Bluetooth);
     for (auto& wiimote : m_wiimotes)
       wiimote->UpdateInput();
     m_last_ticks = now;

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -210,8 +210,9 @@ std::optional<IPCReply> USB_KBD::Write(const ReadWriteRequest& request)
 
 std::optional<IPCReply> USB_KBD::IOCtl(const IOCtlRequest& request)
 {
+  // Manually ignore based on the control gate
   if (SConfig::GetInstance().m_WiiKeyboard && !Core::WantsDeterminism() &&
-      ControlReference::GetInputGate() && !m_message_queue.empty())
+      ControlReference::IsCurrentGateFullyOpen() && !m_message_queue.empty())
   {
     Memory::CopyToEmu(request.buffer_out, &m_message_queue.front(), sizeof(MessageData));
     m_message_queue.pop();

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -63,6 +63,8 @@ add_executable(dolphin-emu
   Config/CommonControllersWidget.h
   Config/ControllerInterface/DualShockUDPClientAddServerDialog.cpp
   Config/ControllerInterface/DualShockUDPClientAddServerDialog.h
+  Config/ControllerInterface/DualShockUDPClientCalibrationDialog.cpp
+  Config/ControllerInterface/DualShockUDPClientCalibrationDialog.h
   Config/ControllerInterface/DualShockUDPClientWidget.cpp
   Config/ControllerInterface/DualShockUDPClientWidget.h
   Config/ControllerInterface/ControllerInterfaceWindow.cpp

--- a/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CommonControllersWidget.cpp
@@ -26,6 +26,7 @@ void CommonControllersWidget::CreateLayout()
   m_common_box = new QGroupBox(tr("Common"));
   m_common_layout = new QVBoxLayout();
   m_common_bg_input = new QCheckBox(tr("Background Input"));
+  m_common_bg_input->setToolTip(tr("Output doesn't require focus unless specified"));
   m_common_configure_controller_interface = new QPushButton(tr("Alternate Input Sources"));
 
   m_common_layout->addWidget(m_common_bg_input);

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.h
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientAddServerDialog.h
@@ -5,6 +5,7 @@
 
 #include <QDialog>
 
+class QComboBox;
 class QDialogButtonBox;
 class QGridLayout;
 class QLineEdit;
@@ -25,4 +26,5 @@ private:
   QLineEdit* m_description;
   QLineEdit* m_server_address;
   QSpinBox* m_server_port;
+  QComboBox* m_type;
 };

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientCalibrationDialog.cpp
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientCalibrationDialog.cpp
@@ -1,0 +1,162 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#include "DolphinQt/Config/ControllerInterface/DualShockUDPClientCalibrationDialog.h"
+
+#include <fmt/format.h>
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QString>
+#include <QTimer>
+#include <QWidget>
+
+#include "Common/Config/Config.h"
+#include "InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h"
+
+DualShockUDPClientCalibrationDialog::DualShockUDPClientCalibrationDialog(QWidget* parent,
+                                                                         int server_index)
+    : QDialog(parent), m_server_index(server_index)
+{
+  CreateWidgets();
+  setLayout(m_main_layout);
+}
+
+void DualShockUDPClientCalibrationDialog::CreateWidgets()
+{
+  setWindowTitle(tr("Calibrate Touch"));
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+  m_main_layout = new QGridLayout;
+  m_main_layout->setSizeConstraint(QLayout::SetFixedSize);
+
+  m_min_x = new QLabel;
+  m_min_y = new QLabel;
+  m_max_x = new QLabel;
+  m_max_y = new QLabel;
+  m_device_state = new QLabel;
+
+  m_main_layout->addWidget(
+      new QLabel(tr("Touch the surface around the top left and the bottom "
+                    "right\nuntil values don't change anymore.\nDS4 and DualSense are already "
+                    "calibrated.\nThe same calibration will apply to all the devices\nconnected "
+                    "from this server.")),
+      0, 0, 1, 2);
+  m_main_layout->addWidget(new QLabel(tr("Min X:")), 1, 0);
+  m_main_layout->addWidget(m_min_x, 1, 1);
+  m_main_layout->addWidget(new QLabel(tr("Min Y:")), 2, 0);
+  m_main_layout->addWidget(m_min_y, 2, 1);
+  m_main_layout->addWidget(new QLabel(tr("Max X:")), 3, 0);
+  m_main_layout->addWidget(m_max_x, 3, 1);
+  m_main_layout->addWidget(new QLabel(tr("Max Y:")), 4, 0);
+  m_main_layout->addWidget(m_max_y, 4, 1);
+  m_main_layout->addWidget(new QLabel(tr("Device State:")), 5, 0);
+  m_main_layout->addWidget(m_device_state, 5, 1);
+
+  m_button_box = new QDialogButtonBox();
+  m_confirm_button = new QPushButton(tr("Confirm"));
+  auto* cancel_button = new QPushButton(tr("Cancel"));
+  m_button_box->addButton(m_confirm_button, QDialogButtonBox::AcceptRole);
+  m_button_box->addButton(cancel_button, QDialogButtonBox::RejectRole);
+  connect(m_confirm_button, &QPushButton::clicked, this,
+          &DualShockUDPClientCalibrationDialog::CommitCalibration);
+  connect(cancel_button, &QPushButton::clicked, this, &DualShockUDPClientCalibrationDialog::reject);
+  m_confirm_button->setDefault(true);
+
+  m_main_layout->addWidget(m_button_box, 6, 0, 1, 2);
+
+  const auto timer = new QTimer(this);
+  connect(timer, &QTimer::timeout, this,
+          &DualShockUDPClientCalibrationDialog::UpdateCalibrationValues);
+  UpdateCalibrationValues();
+  timer->start(1000 / 60);  // ~60Hz
+}
+
+void DualShockUDPClientCalibrationDialog::UpdateCalibrationValues()
+{
+  QString x_min = tr("None");
+  QString y_min = x_min;
+  QString x_max = x_min;
+  QString y_max = x_min;
+  // g_calibration_device_found won't be set back to false if the device is detached
+  // because Dolphin isn't even aware of that, and it's not a problem anyway
+  if (ciface::DualShockUDPClient::g_calibration_device_found)
+  {
+    const bool x_calibration_valid = ciface::DualShockUDPClient::g_calibration_touch_x_max >
+                                     ciface::DualShockUDPClient::g_calibration_touch_x_min;
+    const bool y_calibration_valid = ciface::DualShockUDPClient::g_calibration_touch_y_max >
+                                     ciface::DualShockUDPClient::g_calibration_touch_y_min;
+    const bool calibration_valid = x_calibration_valid && y_calibration_valid;
+    if (x_calibration_valid)
+    {
+      x_min = QStringLiteral("%1").arg(ciface::DualShockUDPClient::g_calibration_touch_x_min);
+      x_max = QStringLiteral("%1").arg(ciface::DualShockUDPClient::g_calibration_touch_x_max);
+    }
+    if (y_calibration_valid)
+    {
+      y_min = QStringLiteral("%1").arg(ciface::DualShockUDPClient::g_calibration_touch_y_min);
+      y_max = QStringLiteral("%1").arg(ciface::DualShockUDPClient::g_calibration_touch_y_max);
+    }
+
+    m_device_state->setText(calibration_valid ? tr("Found. Calibration Valid") :
+                                                tr("Found. Calibration Invalid"));
+    m_confirm_button->setEnabled(calibration_valid);
+  }
+  else
+  {
+    m_device_state->setText(tr("Not Found"));
+    m_confirm_button->setEnabled(false);
+  }
+
+  m_min_x->setText(x_min);
+  m_min_y->setText(y_min);
+  m_max_x->setText(x_max);
+  m_max_y->setText(y_max);
+}
+
+void DualShockUDPClientCalibrationDialog::CommitCalibration()
+{
+  const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
+  auto server_details = SplitString(servers_setting, ';');
+  std::string new_server_setting;
+
+  for (size_t i = 0; i < server_details.size(); i++)
+  {
+    if (i == m_server_index)
+    {
+      std::string new_server_info;
+      auto server_info = SplitString(server_details[i], ':');
+      constexpr int CALIBRATION_INDEX = 4;
+      // If we don't have index 3 and 4, add them now as empty, which is accepted
+      while (server_info.size() <= CALIBRATION_INDEX)
+      {
+        server_info.emplace_back();
+      }
+      for (size_t k = 0; k < server_info.size(); k++)
+      {
+        if (k == CALIBRATION_INDEX)
+        {
+          server_info[k] = fmt::format("({},{},{},{})", m_min_x->text().toStdString(),
+                                       m_min_y->text().toStdString(), m_max_x->text().toStdString(),
+                                       m_max_y->text().toStdString());
+        }
+        new_server_info += server_info[k];
+        if (k + 1 != server_info.size())
+        {
+          new_server_info += ':';
+        }
+      }
+      server_details[i] = new_server_info;
+    }
+
+    new_server_setting += server_details[i] + ';';
+  }
+
+  Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS, new_server_setting);
+
+  accept();
+}

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientCalibrationDialog.h
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientCalibrationDialog.h
@@ -1,0 +1,35 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+class QDialogButtonBox;
+class QGridLayout;
+class QLabel;
+
+class DualShockUDPClientCalibrationDialog final : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit DualShockUDPClientCalibrationDialog(QWidget* parent, int server_index);
+
+private:
+  void CreateWidgets();
+
+  void UpdateCalibrationValues();
+  void CommitCalibration();
+
+  QDialogButtonBox* m_button_box;
+  QPushButton* m_confirm_button;
+  QGridLayout* m_main_layout;
+  QLabel* m_min_x;
+  QLabel* m_min_y;
+  QLabel* m_max_x;
+  QLabel* m_max_y;
+  QLabel* m_device_state;
+
+  const int m_server_index;
+};

--- a/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.h
+++ b/Source/Core/DolphinQt/Config/ControllerInterface/DualShockUDPClientWidget.h
@@ -16,10 +16,6 @@ class DualShockUDPClientWidget final : public QWidget
 public:
   explicit DualShockUDPClientWidget();
 
-signals:
-  // Emitted when config has changed so widgets can update to reflect the change.
-  void ConfigChanged();
-
 private:
   void CreateWidgets();
   void ConnectWidgets();
@@ -27,11 +23,16 @@ private:
   void RefreshServerList();
 
   void OnServerAdded();
+  void OnServerSelectionChanged();
   void OnServerRemoved();
-  void OnServersToggled();
+  void OnServersEnabledToggled();
+
+  void OnCalibration();
+  void OnCalibrationEnded();
 
   QCheckBox* m_servers_enabled;
   QListWidget* m_server_list;
+  QPushButton* m_calibrate;
   QPushButton* m_add_server;
   QPushButton* m_remove_server;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.cpp
@@ -18,8 +18,10 @@
 #include <QSlider>
 #include <QSpinBox>
 #include <QTableWidget>
+#include <QToolTip>
 #include <QVBoxLayout>
 
+#include "Core/ConfigManager.h"
 #include "Core/Core.h"
 
 #include "DolphinQt/Config/Mapping/MappingCommon.h"
@@ -32,10 +34,12 @@
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControlReference/ExpressionParser.h"
+#include "InputCommon/ControlReference/FunctionExpression.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-constexpr int SLIDER_TICK_COUNT = 100;
+constexpr int RANGE_PERCENTAGE = 100;
 
 namespace
 {
@@ -88,6 +92,33 @@ QTextCharFormat GetCommentCharFormat()
   QTextCharFormat format;
   format.setForeground(QBrush{Qt::darkGray});
   return format;
+}
+
+// Only works if there is at least one empty space per length.
+// Might be useful to have somewhere generic but we don't have such class.
+QString SplitTooltip(QString text, int length)
+{
+  QString result;
+  for (;;)
+  {
+    int i = 0;
+    while (i < text.length())
+    {
+      if (text.left(++i + 1).length() > length)
+      {
+        int j = text.lastIndexOf(QLatin1Char{' '}, i);
+        if (j > 0)
+          i = j;
+        result.append(text.left(i));
+        result.append(QLatin1Char{'\n'});
+        text = text.mid(i + 1);
+        break;
+      }
+    }
+    if (i >= text.length())
+      break;
+  }
+  return result + text;
 }
 }  // namespace
 
@@ -198,22 +229,27 @@ private:
   int m_column;
 };
 
+// Also used for output
 class InputStateLineEdit : public QLineEdit
 {
 public:
-  explicit InputStateLineEdit(std::function<ControlState()> state_evaluator);
+  explicit InputStateLineEdit(std::function<ControlState()> state_evaluator, ControlState min = 0.0,
+                              ControlState max = 1.0);
   void SetShouldPaintStateIndicator(bool value);
   void paintEvent(QPaintEvent* event) override;
 
 private:
   std::function<ControlState()> m_state_evaluator;
   bool m_should_paint_state_indicator;
+  ControlState m_min;
+  ControlState m_max;
 };
 
 IOWindow::IOWindow(MappingWidget* parent, ControllerEmu::EmulatedController* controller,
-                   ControlReference* ref, IOWindow::Type type)
-    : QDialog(parent), m_reference(ref), m_original_expression(ref->GetExpression()),
-      m_controller(controller), m_type(type)
+                   ControlReference* ref, IOWindow::Type type, const QString& name,
+                   ControllerEmu::NumericSettingBase* numeric_setting)
+    : QDialog(parent), m_reference(ref), m_controller(controller), m_devq(), m_type(type),
+      m_numeric_setting(numeric_setting)
 {
   CreateMainLayout();
 
@@ -221,7 +257,13 @@ IOWindow::IOWindow(MappingWidget* parent, ControllerEmu::EmulatedController* con
   connect(parent->GetParent(), &MappingWindow::ConfigChanged, this, &IOWindow::ConfigChanged);
   connect(&Settings::Instance(), &Settings::ConfigChanged, this, &IOWindow::ConfigChanged);
 
-  setWindowTitle(type == IOWindow::Type::Input ? tr("Configure Input") : tr("Configure Output"));
+  QString title =
+      m_type == IOWindow::Type::Output ?
+          tr("Configure Output") :
+          (m_type == IOWindow::Type::Input ? tr("Configure Input") : tr("Configure Input Setting"));
+  if (!name.isEmpty())
+    title.append(QStringLiteral(": %1").arg(name));
+  setWindowTitle(title);
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   ConfigChanged();
@@ -240,18 +282,50 @@ void IOWindow::CreateMainLayout()
 
   m_devices_combo = new QComboBox();
   m_option_list = new QTableWidget();
-  m_select_button = new QPushButton(tr("Select"));
+  m_help_button = new QPushButton(tr("Help"));
+  m_select_button = new QPushButton(tr("Add Selected"));
   m_detect_button = new QPushButton(tr("Detect"), this);
-  m_test_button = new QPushButton(tr("Test"), this);
+  m_test_selected_button = new QPushButton(tr("Test Selected"), this);
+  m_test_results_button = new QPushButton(tr("Test Results"), this);
   m_button_box = new QDialogButtonBox();
   m_clear_button = new QPushButton(tr("Clear"));
   m_range_slider = new QSlider(Qt::Horizontal);
   m_range_spinbox = new QSpinBox();
+  m_focus_label = new QLabel();
 
-  m_parse_text = new InputStateLineEdit([this] {
-    const auto lock = m_controller->GetStateLock();
-    return m_reference->GetState<ControlState>();
-  });
+  m_select_button->setEnabled(false);
+  m_test_selected_button->setEnabled(false);
+
+  m_detect_button->setToolTip(
+      tr("Detect input from the current device.\nNote that some inputs can't be detected."));
+  m_focus_label->setToolTip(
+      tr("Window Focus.\nThese requirements could be ignored depending on your settings"));
+
+  if (m_numeric_setting)
+  {
+    m_parse_text = new InputStateLineEdit(
+        [this] {
+          if (m_reference->IsInput())
+          {
+            // This is needed because numeric settings simplify the expression (and set it to
+            // nullptr/"") when they have a simple value, so we don't want to read the expression
+            // value anymore, but their cached in custom value.
+            return m_numeric_setting->GetGenericValue();
+          }
+          return 0.0;
+        },
+        m_numeric_setting->GetGenericMinValue(), m_numeric_setting->GetGenericMaxValue());
+  }
+  else
+  {
+    m_parse_text = new InputStateLineEdit([this] {
+      // Note that ControlReference values are cached upfront, so they might look
+      // different from the values in the inputs list
+      if (m_reference->IsInput())
+        return m_reference->GetState<ControlState>();
+      return 0.0;
+    });
+  }
   m_parse_text->setReadOnly(true);
 
   m_expression_text = new QPlainTextEdit();
@@ -261,7 +335,8 @@ void IOWindow::CreateMainLayout()
   m_operators_combo = new QComboBoxWithMouseWheelDisabled(this);
   m_operators_combo->addItem(tr("Operators"));
   m_operators_combo->insertSeparator(1);
-  if (m_type == Type::Input)
+  // These operators won't be needed with Outputs
+  if (m_type == Type::Input || m_type == Type::InputSetting)
   {
     m_operators_combo->addItem(tr("! Not"));
     m_operators_combo->addItem(tr("* Multiply"));
@@ -269,42 +344,106 @@ void IOWindow::CreateMainLayout()
     m_operators_combo->addItem(tr("% Modulo"));
     m_operators_combo->addItem(tr("+ Add"));
     m_operators_combo->addItem(tr("- Subtract"));
-    m_operators_combo->addItem(tr("> Greater-than"));
-    m_operators_combo->addItem(tr("< Less-than"));
+    m_operators_combo->addItem(tr("> Greater than"));
+    m_operators_combo->addItem(tr("< Less than"));
     m_operators_combo->addItem(tr("& And"));
-    m_operators_combo->addItem(tr("^ Xor"));
   }
   m_operators_combo->addItem(tr("| Or"));
   m_operators_combo->addItem(tr("$ User Variable"));
-  if (m_type == Type::Input)
+  if (m_type == Type::Input || m_type == Type::InputSetting)
   {
+    m_operators_combo->addItem(tr("^ Xor"));
+    m_operators_combo->addItem(tr("= Assign"));
+    m_operators_combo->addItem(tr("$ User variable"));
     m_operators_combo->addItem(tr(", Comma"));
   }
 
   m_functions_combo = new QComboBoxWithMouseWheelDisabled(this);
   m_functions_combo->addItem(tr("Functions"));
-  m_functions_combo->insertSeparator(1);
-  m_functions_combo->addItem(QStringLiteral("if"));
-  m_functions_combo->addItem(QStringLiteral("timer"));
-  m_functions_combo->addItem(QStringLiteral("toggle"));
-  m_functions_combo->addItem(QStringLiteral("deadzone"));
-  m_functions_combo->addItem(QStringLiteral("smooth"));
-  m_functions_combo->addItem(QStringLiteral("hold"));
-  m_functions_combo->addItem(QStringLiteral("tap"));
-  m_functions_combo->addItem(QStringLiteral("relative"));
-  m_functions_combo->addItem(QStringLiteral("pulse"));
-  m_functions_combo->addItem(QStringLiteral("sin"));
-  m_functions_combo->addItem(QStringLiteral("cos"));
-  m_functions_combo->addItem(QStringLiteral("tan"));
-  m_functions_combo->addItem(QStringLiteral("asin"));
-  m_functions_combo->addItem(QStringLiteral("acos"));
-  m_functions_combo->addItem(QStringLiteral("atan"));
-  m_functions_combo->addItem(QStringLiteral("atan2"));
-  m_functions_combo->addItem(QStringLiteral("sqrt"));
-  m_functions_combo->addItem(QStringLiteral("pow"));
-  m_functions_combo->addItem(QStringLiteral("min"));
-  m_functions_combo->addItem(QStringLiteral("max"));
-  m_functions_combo->addItem(QStringLiteral("clamp"));
+  m_functions_combo->setToolTip(
+      tr("Most functions take arguments (arg): you can either put a control there,\na constant "
+         "number or any other function.\n[arg] means that it's optional and can be not "
+         "inserted.\n\"arg = x\" means that it will "
+         "default to that value if you don't specify it.\n\"...\" means unlimited args are "
+         "supported.\n\nWhen functions ask for a number of frames, they are usually input update "
+         "frames,\nwhich differ from video frames (the video refresh rate, not the game "
+         "FPS).\nWhen functions ask for a time, it's usually used as game time, not real world "
+         "time.\nDon't try to mix input and output functions and expect them work.\nTheir state is "
+         "updated even when emulation is not running and will carry over"));
+  // This might cause an empty unselectable whitespace at the end of the ComboBox selection.
+  // Given that a separator is also an item, we add an empty "func param" to keep indexes aligned.
+  m_functions_combo->insertSeparator(m_functions_combo->count());
+  m_functions_parameters.push_back(QStringLiteral(""));
+  // Logic/Math:
+  AddFunction("if");
+  AddFunction("not");
+  AddFunction("min");
+  AddFunction("max");
+  AddFunction("clamp");
+  AddFunction("minus");
+  AddFunction("pow");
+  AddFunction("sqrt");
+  AddFunction("sin");
+  AddFunction("cos");
+  AddFunction("tan");
+  AddFunction("asin");
+  AddFunction("acos");
+  AddFunction("atan");
+  AddFunction("atan2");
+  if (m_type == Type::Output)
+  {
+    AddFunction("scaleSet");
+  }
+  m_functions_combo->insertSeparator(m_functions_combo->count());
+  m_functions_parameters.push_back(QStringLiteral(""));
+  // State/time based:
+  AddFunction("onPress");
+  AddFunction("onRelease");
+  AddFunction("onChange");
+  AddFunction("onHold");
+  AddFunction("onTap");
+  AddFunction("cache");
+  AddFunction("toggle");
+  AddFunction("sharedRelative");
+  AddFunction("relativeToSpeed");
+  AddFunction("smooth");
+  AddFunction("pulse");
+  AddFunction("timer");
+  AddFunction("interval");
+  m_functions_combo->insertSeparator(m_functions_combo->count());
+  m_functions_parameters.push_back(QStringLiteral(""));
+  // Recordings:
+  AddFunction("average");
+  AddFunction("sum");
+  AddFunction("record");
+  AddFunction("sequence");
+  AddFunction("lag");
+  m_functions_combo->insertSeparator(m_functions_combo->count());
+  m_functions_parameters.push_back(QStringLiteral(""));
+  // Stick helpers:
+  AddFunction("deadzone");
+  AddFunction("antiDeadzone");
+  AddFunction("bezierCurve");
+  AddFunction("antiAcceleration");
+  m_functions_combo->insertSeparator(m_functions_combo->count());
+  m_functions_parameters.push_back(QStringLiteral(""));
+  // Meta/Focus:
+  AddFunction("gameSpeed");
+  AddFunction("aspectRatio");
+  AddFunction("timeToInputFrames");
+  AddFunction("videoToInputFrames");
+  AddFunction("hasFocus");
+  // These functions can't be used on input settings (they would just be ignored)
+  if (m_type != Type::InputSetting)
+  {
+    AddFunction("requireFocus");
+  }
+  AddFunction("ignoreFocus");
+  // These wouldn't make sense on outputs or inputs settings
+  if (m_type == Type::Input)
+  {
+    AddFunction("ignoreOnFocusChange");
+  }
 
   m_variables_combo = new QComboBoxWithMouseWheelDisabled(this);
   m_variables_combo->addItem(tr("User Variables"));
@@ -320,20 +459,26 @@ void IOWindow::CreateMainLayout()
 
   // Range
   auto* range_hbox = new QHBoxLayout();
-  range_hbox->addWidget(new QLabel(tr("Range")));
+  range_hbox->addWidget(new QLabel(tr("Range (%)")));
   range_hbox->addWidget(m_range_slider);
   range_hbox->addWidget(m_range_spinbox);
-  m_range_slider->setMinimum(-500);
-  m_range_slider->setMaximum(500);
-  m_range_spinbox->setMinimum(-500);
-  m_range_spinbox->setMaximum(500);
-  m_main_layout->addLayout(range_hbox);
+  // Being a double spin box would allow us more accuracy, but that's why we made it a percentage
+  m_range_spinbox->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+  m_range_slider->setRange(-RANGE_PERCENTAGE * 5, RANGE_PERCENTAGE * 5);
+  m_range_slider->setTickPosition(QSlider::TickPosition::TicksBelow);
+  m_range_slider->setTickInterval(RANGE_PERCENTAGE);
+  m_range_slider->setToolTip(tr("Multiplies (not clamp) the final result. Defaults to %1")
+                                 .arg(m_reference->default_range * RANGE_PERCENTAGE));
+  m_range_spinbox->setToolTip(m_range_slider->toolTip());
+  // If this is an input setting, the range won't be saved in our config,
+  // nor it would make sense to change it, so just hide it
+  if (m_type != Type::InputSetting)
+    m_main_layout->addLayout(range_hbox);
 
   // Options (Buttons, Outputs) and action buttons
 
-  m_option_list->setTabKeyNavigation(false);
-
-  if (m_type == Type::Input)
+  // Preview input values
+  if (m_type == Type::Input || m_type == Type::InputSetting)
   {
     m_option_list->setColumnCount(2);
     m_option_list->setColumnWidth(1, 64);
@@ -350,6 +495,7 @@ void IOWindow::CreateMainLayout()
     m_option_list->setColumnCount(1);
   }
 
+  m_option_list->setTabKeyNavigation(false);
   m_option_list->horizontalHeader()->hide();
   m_option_list->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
   m_option_list->verticalHeader()->hide();
@@ -364,24 +510,27 @@ void IOWindow::CreateMainLayout()
   hbox->addWidget(m_option_list, 8);
   hbox->addLayout(button_vbox, 1);
 
+  button_vbox->addWidget(m_help_button);
   button_vbox->addWidget(m_select_button);
 
-  if (m_type == Type::Input)
+  if (m_type == Type::Input || m_type == Type::InputSetting)
   {
-    m_test_button->hide();
+    m_test_selected_button->hide();
+    m_test_results_button->hide();
     button_vbox->addWidget(m_detect_button);
   }
   else
   {
     m_detect_button->hide();
-    button_vbox->addWidget(m_test_button);
+    button_vbox->addWidget(m_test_selected_button);
+    button_vbox->addWidget(m_test_results_button);
   }
 
   button_vbox->addWidget(m_variables_combo);
 
   button_vbox->addWidget(m_operators_combo);
 
-  if (m_type == Type::Input)
+  if (m_functions_combo->count() > 2)
     button_vbox->addWidget(m_functions_combo);
   else
     m_functions_combo->hide();
@@ -390,12 +539,85 @@ void IOWindow::CreateMainLayout()
   m_main_layout->addWidget(m_expression_text, 1);
   m_main_layout->addWidget(m_parse_text);
 
+  auto* hbox2 = new QHBoxLayout();
+  hbox2->addWidget(m_focus_label, Qt::AlignLeft);
+
   // Button Box
-  m_main_layout->addWidget(m_button_box);
   m_button_box->addButton(m_clear_button, QDialogButtonBox::ActionRole);
   m_button_box->addButton(QDialogButtonBox::Ok);
+  hbox2->addWidget(m_button_box, Qt::AlignRight);
+
+  m_main_layout->addLayout(hbox2, 2);
 
   setLayout(m_main_layout);
+}
+
+void IOWindow::AddFunction(std::string function_name)
+{
+  using namespace ciface::ExpressionParser;
+
+  // Try to instantiate the function by name
+  std::unique_ptr<FunctionExpression> func = MakeFunctionExpression(function_name);
+
+  // Don't do anything if the function doesn't exist
+  if (func.get() == nullptr)
+  {
+    return;
+  }
+
+  m_functions_combo->addItem(QString::fromStdString(function_name));
+
+  // Try to set the empty function arguments, which will return a corrected version
+  // if they are not valid.
+  std::vector<std::unique_ptr<Expression>> fake_args;
+  const auto argument_validation = func->SetArguments(std::move(fake_args));
+
+  QString func_tooltip;
+
+  // If the fake empty arguments are invalid, pre-fill commas between them.
+  // We don't add the argument names themselves because names are always parsed correctly,
+  // so the expression would be accepted. Also, errors are visible at the bottom of the widget
+  if (std::holds_alternative<FunctionExpression::ExpectedArguments>(argument_validation))
+  {
+    std::string correct_args =
+        std::get<FunctionExpression::ExpectedArguments>(argument_validation).text;
+
+    int commas_num = std::count(correct_args.begin(), correct_args.end(), ',');
+    int brackets_num = std::count(correct_args.begin(), correct_args.end(), '[');
+    int equals_num = std::count(correct_args.begin(), correct_args.end(), '=');
+
+    // Arguments that either have brackets or equal are not mandatory.
+    // As an alternative we should just pass in an increasing number of argments,
+    // and see the first number that gets accepted
+    commas_num -= brackets_num;
+    commas_num -= equals_num;
+
+    std::string commas = "";
+    while (commas_num > 0)
+    {
+      commas += ",";
+      --commas_num;
+    }
+
+    // Arguments won't be translated, just like function names
+    func_tooltip = tr("Arguments: %1").arg(QString::fromStdString(correct_args));
+    m_functions_parameters.push_back(QString::fromStdString(commas));
+  }
+  // Note that there might still be some optional arguments in this case,
+  // we can't easily tell without spamming any params num to the func
+  else
+  {
+    func_tooltip = tr("No required arguments");
+    m_functions_parameters.push_back(QStringLiteral(""));
+  }
+
+  if (const char* description = func->GetDescription(m_type != Type::Output))
+  {
+    func_tooltip.append(QStringLiteral("\n%1").arg(tr(description)));
+  }
+
+  m_functions_combo->setItemData(m_functions_combo->count() - 1, SplitTooltip(func_tooltip, 72),
+                                 Qt::ToolTipRole);
 }
 
 void IOWindow::ConfigChanged()
@@ -403,13 +625,31 @@ void IOWindow::ConfigChanged()
   const QSignalBlocker blocker(this);
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
 
+  if (m_numeric_setting && m_numeric_setting->IsSimpleValue())
+    m_numeric_setting->SetExpressionFromValue();
+
+  m_original_expression = m_reference->GetExpression();
+
+  m_original_range = m_reference->range;
+  OnRangeChanged();
+
   // ensure m_parse_text is in the right state
   UpdateExpression(m_reference->GetExpression(), UpdateMode::Force);
 
-  m_expression_text->setPlainText(QString::fromStdString(m_reference->GetExpression()));
+  {
+    const QSignalBlocker blocker_expression(m_expression_text);
+    // The expression could be empty in this case so fill it up
+    if (m_numeric_setting && m_numeric_setting->IsSimpleValue())
+    {
+      m_expression_text->setPlainText(
+          QString::fromStdString(m_numeric_setting->GetExpressionFromValue()));
+    }
+    else
+    {
+      m_expression_text->setPlainText(QString::fromStdString(m_reference->GetExpression()));
+    }
+  }
   m_expression_text->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
-  m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
-  m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
 
   if (m_devq.ToString().empty())
     m_devq = m_controller->GetDefaultDevice();
@@ -426,16 +666,40 @@ void IOWindow::Update()
 void IOWindow::ConnectWidgets()
 {
   connect(m_select_button, &QPushButton::clicked, [this] { AppendSelectedOption(); });
+  connect(m_option_list, &QTableWidget::cellDoubleClicked, [this] { AppendSelectedOption(); });
+  connect(m_option_list, &QTableWidget::itemSelectionChanged, [this] {
+    const bool any_selected = m_option_list->currentRow() >= 0;
+    m_test_selected_button->setEnabled(any_selected);
+    m_select_button->setEnabled(any_selected);
+  });
+
+  connect(m_help_button, &QPushButton::clicked, [this] {
+    QString help_tooltip =
+        tr("You can either simply bind an %1 or use functions\nand operators to achieve more "
+           "complex results.\nYou can bind controls from multiple devices.%2\nSee more "
+           "at https://wiki.dolphin-emu.org/index.php?title=Input_Syntax")
+            .arg(m_type != Type::Input ? tr("output") : tr("input"))
+            .arg(m_type != Type::Input ?
+                     QString() :
+                     tr("\nSome inputs are relative and might need to be converted\nto a rate or "
+                        "smoothed over time to be correctly mapped."));
+    QToolTip::showText(QCursor::pos(), help_tooltip, this);
+  });
+
   connect(&Settings::Instance(), &Settings::ReleaseDevices, this, &IOWindow::ReleaseDevices);
   connect(&Settings::Instance(), &Settings::DevicesChanged, this, &IOWindow::UpdateDeviceList);
 
   connect(m_detect_button, &QPushButton::clicked, this, &IOWindow::OnDetectButtonPressed);
-  connect(m_test_button, &QPushButton::clicked, this, &IOWindow::OnTestButtonPressed);
+  connect(m_test_selected_button, &QPushButton::clicked, this,
+          &IOWindow::OnTestSelectedButtonPressed);
+  connect(m_test_results_button, &QPushButton::clicked, this,
+          &IOWindow::OnTestResultsButtonPressed);
 
   connect(m_button_box, &QDialogButtonBox::clicked, this, &IOWindow::OnDialogButtonPressed);
   connect(m_devices_combo, &QComboBox::currentTextChanged, this, &IOWindow::OnDeviceChanged);
   connect(m_range_spinbox, qOverload<int>(&QSpinBox::valueChanged), this,
-          &IOWindow::OnRangeChanged);
+          &IOWindow::OnUIRangeChanged);
+  connect(m_range_slider, &QSlider::valueChanged, this, &IOWindow::OnUIRangeChanged);
 
   connect(m_expression_text, &QPlainTextEdit::textChanged,
           [this] { UpdateExpression(m_expression_text->toPlainText().toStdString()); });
@@ -471,13 +735,19 @@ void IOWindow::ConnectWidgets()
     if (index == 0)
       return;
 
-    m_expression_text->insertPlainText(m_functions_combo->currentText() + QStringLiteral("()"));
+    m_expression_text->insertPlainText(m_functions_combo->currentText() + QLatin1Char('(') +
+                                       m_functions_parameters[index - 1] + QLatin1Char(')'));
 
     m_functions_combo->setCurrentIndex(0);
   });
 
-  // revert the expression when the window closes without using the OK button
-  connect(this, &IOWindow::finished, [this] { UpdateExpression(m_original_expression); });
+  // revert the expression and range changes when the window closes without using the OK button
+  connect(this, &IOWindow::finished, [this] {
+    // Lock just to be sure, range is atomic. Also it can't have changed if we are an input setting.
+    const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+    m_reference->range = m_original_range;
+    UpdateExpression(m_original_expression);
+  });
 }
 
 void IOWindow::AppendSelectedOption()
@@ -500,6 +770,7 @@ void IOWindow::OnDeviceChanged()
 
 void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
 {
+  // Clear button won't save the results unless we click OK
   if (button == m_clear_button)
   {
     m_expression_text->clear();
@@ -508,8 +779,16 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
 
   const auto lock = ControllerEmu::EmulatedController::GetStateLock();
 
+  // Update the original expression and range as they will be set back when this widget closes.
+
+  m_original_range = m_reference->range;
+
   UpdateExpression(m_expression_text->toPlainText().toStdString());
-  m_original_expression = m_reference->GetExpression();
+  // Numeric setting string needs to be reconstructed or it will break the state.
+  if (m_numeric_setting && m_numeric_setting->IsSimpleValue())
+    m_original_expression = m_numeric_setting->GetExpressionFromValue();
+  else
+    m_original_expression = m_reference->GetExpression();
 
   if (ciface::ExpressionParser::ParseStatus::SyntaxError == m_reference->GetParseStatus())
   {
@@ -522,9 +801,11 @@ void IOWindow::OnDialogButtonPressed(QAbstractButton* button)
 
 void IOWindow::OnDetectButtonPressed()
 {
-  const auto expression =
-      MappingCommon::DetectExpression(m_detect_button, g_controller_interface, {m_devq.ToString()},
-                                      m_devq, MappingCommon::Quote::Off);
+  // In this case, we don't want input to be redirected to the parent input
+  // (e.g. LCTRL to combined CTRL)
+  const auto expression = MappingCommon::DetectExpression(
+      m_detect_button, g_controller_interface, {m_devq.ToString()}, m_devq,
+      MappingCommon::ExpressionType::QuoteOffAndRedirectToParentInputOff);
 
   if (expression.isEmpty())
     return;
@@ -536,16 +817,43 @@ void IOWindow::OnDetectButtonPressed()
     m_option_list->setCurrentItem(list[0]);
 }
 
-void IOWindow::OnTestButtonPressed()
+void IOWindow::OnTestSelectedButtonPressed()
 {
-  MappingCommon::TestOutput(m_test_button, static_cast<OutputReference*>(m_reference));
+  std::lock_guard lock(m_selected_device_mutex);
+  if (m_option_list->currentRow() < 0 || GetSelectedDevice() == nullptr)
+    return;
+
+  MappingCommon::TestOutput(
+      m_test_selected_button, g_controller_interface, GetSelectedDevice().get(),
+      m_option_list->item(m_option_list->currentRow(), 0)->text().toStdString());
 }
 
-void IOWindow::OnRangeChanged(int value)
+void IOWindow::OnTestResultsButtonPressed()
 {
-  m_reference->range = static_cast<double>(value) / SLIDER_TICK_COUNT;
-  m_range_spinbox->setValue(m_reference->range * SLIDER_TICK_COUNT);
-  m_range_slider->setValue(m_reference->range * SLIDER_TICK_COUNT);
+  MappingCommon::TestOutput(m_test_results_button, static_cast<OutputReference*>(m_reference));
+}
+
+void IOWindow::OnUIRangeChanged(int value)
+{
+  // Lock just to be sure, range is atomic
+  const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+  m_reference->range = static_cast<ControlState>(value) / RANGE_PERCENTAGE;
+  OnRangeChanged();
+}
+
+void IOWindow::OnRangeChanged()
+{
+  // Rounding is needed or it loses accuracy
+  const int qt_value = int(std::round(m_reference->range * RANGE_PERCENTAGE));
+  const int slider_range = std::max(m_range_slider->maximum(), std::abs(qt_value));
+  // Increase the range of the slider if necessary, we don't want any limts
+  m_range_slider->setRange(-slider_range, slider_range);
+  if (slider_range > 1000)  // Hide ticks above 1000 or it becomes too expensive to render
+    m_range_slider->setTickPosition(QSlider::TickPosition::NoTicks);
+  const QSignalBlocker blocker_range_spinbox(m_range_spinbox);
+  const QSignalBlocker blocker_range_slider(m_range_slider);
+  m_range_spinbox->setValue(qt_value);
+  m_range_slider->setValue(qt_value);
 }
 
 void IOWindow::ReleaseDevices()
@@ -647,17 +955,37 @@ void IOWindow::UpdateDeviceList()
   OnDeviceChanged();
 }
 
+// Note that if the emulation is running while we are editing the expression,
+// it will use whatever expression we have in the editor, not the previous one
 void IOWindow::UpdateExpression(std::string new_expression, UpdateMode mode)
 {
-  const auto lock = m_controller->GetStateLock();
-  if (mode != UpdateMode::Force && new_expression == m_reference->GetExpression())
+  const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+  // Always force if it's a numeric setting or an empty expression wouldn't be simplified to 0
+  if (mode != UpdateMode::Force && new_expression == m_reference->GetExpression() &&
+      !m_numeric_setting)
     return;
 
-  const auto error = m_reference->SetExpression(std::move(new_expression));
+  auto error = m_reference->SetExpression(std::move(new_expression));
+  // If this is a numeric setting, we want to simplify the expression straight away,
+  // otherwise this widget would try to read the value from the expression.
+  // The only behavioural different from a user point of view should be that
+  // inputs named as a single digit number, e.g. (0, 1, ...) that aren't wrapped
+  // around `` will be treated as simple value and not as key, as in input expressions.
+  if (m_numeric_setting)
+  {
+    m_numeric_setting->SimplifyIfPossible();
+    if (m_numeric_setting->IsSimpleValue())
+    {
+      // Here we are actually separating the m_expression_text value from the actual internal
+      // expression value. This is because if you are about to write a complex expression that
+      // starts with a simple one, we don't want to prevent you from doing so.
+      error.reset();
+    }
+  }
   const auto status = m_reference->GetParseStatus();
   m_controller->UpdateSingleControlReference(g_controller_interface, m_reference);
 
-  // This is the only place where we need to update the user variables. Keep the first 4 items.
+  // This is the only place where we need to update the user variables. keep the first 4 items.
   while (m_variables_combo->count() > 4)
   {
     m_variables_combo->removeItem(m_variables_combo->count() - 1);
@@ -667,14 +995,17 @@ void IOWindow::UpdateExpression(std::string new_expression, UpdateMode mode)
     m_variables_combo->addItem(QString::fromStdString(expression.first));
   }
 
+  QString state_appended_string;
   if (error)
   {
+    // There might be a valid value here but we don't paint it to make it clear there is an error
     m_parse_text->SetShouldPaintStateIndicator(false);
     m_parse_text->setText(QString::fromStdString(*error));
   }
   else if (status == ciface::ExpressionParser::ParseStatus::EmptyExpression)
   {
-    m_parse_text->SetShouldPaintStateIndicator(false);
+    // This will always paint 0
+    m_parse_text->SetShouldPaintStateIndicator(m_reference->IsInput());
     m_parse_text->setText(QString());
   }
   else if (status != ciface::ExpressionParser::ParseStatus::Successful)
@@ -684,9 +1015,59 @@ void IOWindow::UpdateExpression(std::string new_expression, UpdateMode mode)
   }
   else
   {
-    m_parse_text->SetShouldPaintStateIndicator(true);
+    m_parse_text->SetShouldPaintStateIndicator(m_reference->IsInput());
     m_parse_text->setText(QString());
+
+    // Show the focus requirements of the expression if they are not the default/expected ones.
+    // Thiese might be ignored depending on your background input settings.
+    if (m_reference->HasExpression())
+    {
+      const Device::FocusFlags focus_flags = m_reference->GetFocusFlags();
+      Device::FocusFlags default_focus_flags;
+      switch (m_type)
+      {
+      case IOWindow::Type::InputSetting:
+        default_focus_flags = Device::FocusFlags::IgnoreFocus;
+        break;
+      case IOWindow::Type::Output:
+        default_focus_flags = Device::FocusFlags::OutputDefault;
+        break;
+      case IOWindow::Type::Input:
+      default:
+        default_focus_flags = Device::FocusFlags::Default;
+        break;
+      }
+
+      if (focus_flags != default_focus_flags)
+      {
+        if (m_type == Type::InputSetting)
+        {
+          state_appended_string = tr("Focus Settings Ignored");
+        }
+        // Flags in order of priority (show the ones that will actually win over)
+        else if (u8(focus_flags) & u8(Device::FocusFlags::IgnoreFocus))
+        {
+          state_appended_string = tr("Ignores Focus");
+        }
+        else
+        {
+          if (u8(focus_flags) & u8(Device::FocusFlags::RequireFullFocus))
+          {
+            state_appended_string = tr("Requires Full Focus");
+          }
+          if ((u8(focus_flags) & u8(Device::FocusFlags::IgnoreOnFocusChanged)) &&
+              m_type == Type::Input)  // Only applies to inputs
+          {
+            if (!state_appended_string.isEmpty())
+              state_appended_string.append(QStringLiteral(", "));
+            state_appended_string.append(tr("Ignored On Focus Change"));
+          }
+        }
+      }
+    }
   }
+
+  m_focus_label->setText(state_appended_string);
 }
 
 InputStateDelegate::InputStateDelegate(IOWindow* parent, int column,
@@ -695,17 +1076,21 @@ InputStateDelegate::InputStateDelegate(IOWindow* parent, int column,
 {
 }
 
-InputStateLineEdit::InputStateLineEdit(std::function<ControlState()> state_evaluator)
-    : m_state_evaluator(std::move(state_evaluator))
+InputStateLineEdit::InputStateLineEdit(std::function<ControlState()> state_evaluator,
+                                       ControlState min, ControlState max)
+    : m_state_evaluator(std::move(state_evaluator)), m_min(min), m_max(max)
 {
 }
 
-static void PaintStateIndicator(QPainter& painter, const QRect& region, ControlState state)
+static void PaintStateIndicator(QPainter& painter, const QRect& region, ControlState state,
+                                ControlState min = 0.0, ControlState max = 1.0)
 {
-  const QString state_string = QString::number(state, 'g', 4);
+  QString state_string = QString::number(state, 'g', 4);
 
   QRect meter_region = region;
-  meter_region.setWidth(region.width() * std::clamp(state, 0.0, 1.0));
+  if (std::isnan(state))  // Avoids drawing backwards (possibly over controls names)
+    state = 0.0;
+  meter_region.setWidth(region.width() * ((std::clamp(state, min, max) - min) / (max - min)));
 
   // Create a temporary indicator object to retreive color constants.
   MappingIndicator indicator;
@@ -750,5 +1135,5 @@ void InputStateLineEdit::paintEvent(QPaintEvent* event)
     return;
 
   QPainter painter(this);
-  PaintStateIndicator(painter, this->rect(), m_state_evaluator());
+  PaintStateIndicator(painter, this->rect(), m_state_evaluator(), m_min, m_max);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/IOWindow.h
@@ -27,11 +27,13 @@ class QPlainTextEdit;
 class QPushButton;
 class QSlider;
 class QSpinBox;
+class QLabel;
 
 namespace ControllerEmu
 {
 class EmulatedController;
-}
+class NumericSettingBase;
+}  // namespace ControllerEmu
 
 class InputStateLineEdit;
 
@@ -52,7 +54,7 @@ public:
   explicit QComboBoxWithMouseWheelDisabled(QWidget* parent = nullptr) : QComboBox(parent) {}
 
 protected:
-  // Consumes event while doing nothing
+  // Consumes event while doing nothing (the combo box will still scroll)
   void wheelEvent(QWheelEvent* event) override;
 };
 
@@ -63,16 +65,19 @@ public:
   enum class Type
   {
     Input,
+    InputSetting,
     Output
   };
 
-  explicit IOWindow(MappingWidget* parent, ControllerEmu::EmulatedController* m_controller,
-                    ControlReference* ref, Type type);
+  explicit IOWindow(MappingWidget* parent, ControllerEmu::EmulatedController* controller,
+                    ControlReference* ref, Type type, const QString& name,
+                    ControllerEmu::NumericSettingBase* numeric_setting = nullptr);
 
 private:
   std::shared_ptr<ciface::Core::Device> GetSelectedDevice() const;
 
   void CreateMainLayout();
+  void AddFunction(std::string function_name);
   void ConnectWidgets();
   void ConfigChanged();
   void Update();
@@ -80,8 +85,10 @@ private:
   void OnDialogButtonPressed(QAbstractButton* button);
   void OnDeviceChanged();
   void OnDetectButtonPressed();
-  void OnTestButtonPressed();
-  void OnRangeChanged(int range);
+  void OnTestSelectedButtonPressed();
+  void OnTestResultsButtonPressed();
+  void OnUIRangeChanged(int range);
+  void OnRangeChanged();
 
   void AppendSelectedOption();
   void UpdateOptionList();
@@ -95,6 +102,8 @@ private:
   };
 
   void UpdateExpression(std::string new_expression, UpdateMode mode = UpdateMode::Normal);
+
+  ControlState GetNumericSettingValue() const;
 
   // Main Layout
   QVBoxLayout* m_main_layout;
@@ -110,31 +119,37 @@ private:
   QSpinBox* m_range_spinbox;
 
   // Shared actions
+  QPushButton* m_help_button;
   QPushButton* m_select_button;
   QComboBox* m_operators_combo;
+  QComboBox* m_functions_combo;
   QComboBox* m_variables_combo;
 
   // Input actions
   QPushButton* m_detect_button;
-  QComboBox* m_functions_combo;
 
   // Output actions
-  QPushButton* m_test_button;
+  QPushButton* m_test_selected_button;
+  QPushButton* m_test_results_button;
 
-  // Textarea
+  // TextArea
   QPlainTextEdit* m_expression_text;
   InputStateLineEdit* m_parse_text;
+  QLabel* m_focus_label;
 
-  // Buttonbox
+  // ButtonBox
   QDialogButtonBox* m_button_box;
   QPushButton* m_clear_button;
 
   ControlReference* m_reference;
   std::string m_original_expression;
+  ControlState m_original_range;
   ControllerEmu::EmulatedController* m_controller;
 
   ciface::Core::DeviceQualifier m_devq;
   Type m_type;
+  ControllerEmu::NumericSettingBase* m_numeric_setting;
   std::shared_ptr<ciface::Core::Device> m_selected_device;
   std::mutex m_selected_device_mutex;
+  std::vector<QString> m_functions_parameters;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.cpp
@@ -18,8 +18,6 @@
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
-constexpr int SLIDER_TICK_COUNT = 100;
-
 // Escape ampersands and simplify the text for a short preview
 static QString RefToDisplayString(ControlReference* ref)
 {
@@ -50,12 +48,15 @@ static QString RefToDisplayString(ControlReference* ref)
         controls[i] = qualifier.has_device ? QStringLiteral(":") : QString();
         controls[i].append(QString::fromStdString(qualifier.control_name));
       }
+      else
+      {
+        controls[i].remove(QLatin1Char{' '});
+      }
     }
   }
   // Do not re-add "`" to the final string, we don't need to see it.
   expression = controls.join(QStringLiteral(""));
 
-  expression.remove(QLatin1Char{' '});
   expression.remove(QLatin1Char{'\t'});
   expression.remove(QLatin1Char{'\n'});
   expression.remove(QLatin1Char{'\r'});
@@ -69,8 +70,10 @@ bool MappingButton::IsInput() const
   return m_reference->IsInput();
 }
 
-MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, bool indicator)
-    : ElidedButton(RefToDisplayString(ref)), m_parent(parent), m_reference(ref)
+MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, bool indicator,
+                             const QString& button_name)
+    : ElidedButton(RefToDisplayString(ref)), m_parent(parent), m_reference(ref),
+      m_button_name(button_name)
 {
   // Force all mapping buttons to stay at a minimal height.
   setFixedHeight(minimumSizeHint().height());
@@ -100,12 +103,18 @@ MappingButton::MappingButton(MappingWidget* parent, ControlReference* ref, bool 
 
 void MappingButton::AdvancedPressed()
 {
+  // Don't update values in the parent widget as we are customizing them. Can't use QSignalBlocker
+  m_parent->SetBlockUpdate(true);
+
   IOWindow io(m_parent, m_parent->GetController(), m_reference,
-              m_reference->IsInput() ? IOWindow::Type::Input : IOWindow::Type::Output);
+              m_reference->IsInput() ? IOWindow::Type::Input : IOWindow::Type::Output,
+              m_button_name);
   io.exec();
 
   ConfigChanged();
   m_parent->SaveSettings();
+
+  m_parent->SetBlockUpdate(false);
 }
 
 void MappingButton::Clicked()
@@ -120,7 +129,7 @@ void MappingButton::Clicked()
 
   QString expression;
 
-  if (m_parent->GetParent()->IsMappingAllDevices())
+  if (m_parent->GetParent()->IsDetectingAllDevices())
   {
     expression = MappingCommon::DetectExpression(this, g_controller_interface,
                                                  g_controller_interface.GetAllDeviceStrings(),
@@ -136,8 +145,11 @@ void MappingButton::Clicked()
   if (expression.isEmpty())
     return;
 
-  m_reference->SetExpression(expression.toStdString());
-  m_parent->GetController()->UpdateSingleControlReference(g_controller_interface, m_reference);
+  {
+    const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+    m_reference->SetExpression(expression.toStdString());
+    m_parent->GetController()->UpdateSingleControlReference(g_controller_interface, m_reference);
+  }
 
   ConfigChanged();
   m_parent->SaveSettings();
@@ -145,10 +157,14 @@ void MappingButton::Clicked()
 
 void MappingButton::Clear()
 {
-  m_reference->range = 100.0 / SLIDER_TICK_COUNT;
+  {
+    const auto lock = ControllerEmu::EmulatedController::GetStateLock();
 
-  m_reference->SetExpression("");
-  m_parent->GetController()->UpdateSingleControlReference(g_controller_interface, m_reference);
+    m_reference->range = m_reference->default_range;
+
+    m_reference->SetExpression("");
+    m_parent->GetController()->UpdateSingleControlReference(g_controller_interface, m_reference);
+  }
 
   m_parent->SaveSettings();
   ConfigChanged();
@@ -156,18 +172,22 @@ void MappingButton::Clear()
 
 void MappingButton::UpdateIndicator()
 {
-  if (!isActiveWindow())
-    return;
-
   QFont f = m_parent->font();
 
-  // If the input state is "true" (we can't know the state of outputs), show it in bold.
-  if (m_reference->IsInput() && m_reference->GetState<bool>())
-    f.setBold(true);
-  // If the expression has failed to parse, show it in italic.
-  // Some expressions still work even the failed to parse so don't prevent the GetState() above.
-  if (m_reference->GetParseStatus() == ciface::ExpressionParser::ParseStatus::SyntaxError)
-    f.setItalic(true);
+  // We don't want to show the results here if we are editing the mapping,
+  // as it would show the previous expression highlighting based on the new (pending)
+  // expression result.
+  if (!m_parent->GetBlockUpdate())
+  {
+    // If the input or output state is "true"
+    // (input comes from the device, output comes from the emulator) show it in bold.
+    if (m_reference->GetState<bool>())
+      f.setBold(true);
+    // If the expression has failed to parse, show it in italic.
+    // Some expressions still work even the failed to parse so don't prevent the GetState() above.
+    if (m_reference->GetParseStatus() == ciface::ExpressionParser::ParseStatus::SyntaxError)
+      f.setItalic(true);
+  }
 
   setFont(f);
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingButton.h
@@ -15,7 +15,8 @@ class MappingButton : public ElidedButton
 {
   Q_OBJECT
 public:
-  MappingButton(MappingWidget* widget, ControlReference* ref, bool indicator);
+  MappingButton(MappingWidget* widget, ControlReference* ref, bool indicator,
+                const QString& button_name);
 
   bool IsInput() const;
 
@@ -30,4 +31,5 @@ private:
 
   MappingWidget* m_parent;
   ControlReference* m_reference;
+  QString m_button_name;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.cpp
@@ -3,7 +3,6 @@
 
 #include "DolphinQt/Config/Mapping/MappingCommon.h"
 
-#include <tuple>
 #include <vector>
 
 #include <QApplication>
@@ -14,6 +13,7 @@
 
 #include "DolphinQt/QtUtils/BlockUserInputFilter.h"
 #include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
 
 #include "Common/Thread.h"
 
@@ -34,7 +34,8 @@ constexpr auto SPURIOUS_TRIGGER_COMBO_THRESHOLD = std::chrono::milliseconds(150)
 
 QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
-                                const ciface::Core::DeviceQualifier& default_device, Quote quote)
+                                const ciface::Core::DeviceQualifier& default_device,
+                                ExpressionType expression_type)
 {
   QString expr;
 
@@ -48,13 +49,10 @@ QString GetExpressionForControl(const QString& control_name,
   // append the control name
   expr += control_name;
 
-  if (quote == Quote::On)
+  if (expression_type == ExpressionType::QuoteOn)
   {
-    // If our expression contains any non-alpha characters
-    // we should quote it
-    const QRegularExpression reg(QStringLiteral("[^a-zA-Z]"));
-    if (reg.match(expr).hasMatch())
-      expr = QStringLiteral("`%1`").arg(expr);
+    // wrap around ` (bareword expressions might work anyway but we do it for consistency)
+    expr = QStringLiteral("`%1`").arg(expr);
   }
 
   return expr;
@@ -62,7 +60,8 @@ QString GetExpressionForControl(const QString& control_name,
 
 QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& device_container,
                          const std::vector<std::string>& device_strings,
-                         const ciface::Core::DeviceQualifier& default_device, Quote quote)
+                         const ciface::Core::DeviceQualifier& default_device,
+                         ExpressionType expression_type)
 {
   const auto filter = new BlockUserInputFilter(button);
 
@@ -76,7 +75,9 @@ QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& dev
   // The button text won't be updated if we don't process events here
   QApplication::processEvents();
 
-  // Avoid that the button press itself is registered as an event
+  // Avoid the input press itself starting as "1/down" in the input detection,
+  // which would then either always or never detect it.
+  // This should always work as input is updated at 60Hz by a different thread.
   Common::SleepCurrentThread(50);
 
   auto detections =
@@ -100,20 +101,57 @@ QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& dev
 
   button->setText(old_text);
 
-  return BuildExpression(detections, default_device, quote);
+  return BuildExpression(detections, default_device, expression_type);
 }
 
-void TestOutput(QPushButton* button, OutputReference* reference)
+void TestOutput(QPushButton* button, ciface::Core::DeviceContainer& device_container,
+                ciface::Core::Device* device, std::string output_name)
 {
+  ciface::Core::Device::Output* output = device->FindOutput(output_name);
+  if (!output)
+    return;
+
   const auto old_text = button->text();
   button->setText(QStringLiteral("..."));
 
   // The button text won't be updated if we don't process events here
   QApplication::processEvents();
 
-  reference->State(1.0);
+  {
+    const auto lock = device_container.GetDevicesOutputLock();
+    output->SetState(1.0, button);
+  }
   std::this_thread::sleep_for(OUTPUT_TEST_TIME);
-  reference->State(0.0);
+  {
+    const auto lock = device_container.GetDevicesOutputLock();
+    output->SetState(0.0, button);
+  }
+
+  button->setText(old_text);
+}
+
+void TestOutput(QPushButton* button, OutputReference* reference)
+{
+  // No point in locking the thread if the expression won't do anything
+  if (reference->GetParseStatus() == ciface::ExpressionParser::ParseStatus::EmptyExpression)
+    return;
+
+  const auto old_text = button->text();
+  button->setText(QStringLiteral("..."));
+
+  // The button text won't be updated if we don't process events here
+  QApplication::processEvents();
+
+  {
+    const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+    reference->SetState(1.0);
+  }
+  // This will hang the UI but it's the simplest way of doing it.
+  std::this_thread::sleep_for(OUTPUT_TEST_TIME);
+  {
+    const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+    reference->SetState(0.0);
+  }
 
   button->setText(old_text);
 }
@@ -135,7 +173,7 @@ void RemoveSpuriousTriggerCombinations(
 
 QString
 BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>& detections,
-                const ciface::Core::DeviceQualifier& default_device, Quote quote)
+                const ciface::Core::DeviceQualifier& default_device, ExpressionType expression_type)
 {
   std::vector<const ciface::Core::DeviceContainer::InputDetection*> pressed_inputs;
 
@@ -145,7 +183,7 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
     // Return the parent-most name if there is one for better hotkey strings.
     // Detection of L/R_Ctrl will be changed to just Ctrl.
     // Users can manually map L_Ctrl if they so desire.
-    const auto input = (quote == Quote::On) ?
+    const auto input = (expression_type != ExpressionType::QuoteOffAndRedirectToParentInputOff) ?
                            detection.device->GetParentMostInput(detection.input) :
                            detection.input;
 
@@ -153,7 +191,8 @@ BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>
     device_qualifier.FromDevice(detection.device.get());
 
     return MappingCommon::GetExpressionForControl(QString::fromStdString(input->GetName()),
-                                                  device_qualifier, default_device, quote);
+                                                  device_qualifier, default_device,
+                                                  expression_type);
   };
 
   bool new_alternation = false;

--- a/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingCommon.h
@@ -14,27 +14,31 @@ class QPushButton;
 
 namespace MappingCommon
 {
-enum class Quote
+enum class ExpressionType
 {
-  On,
-  Off
+  QuoteOn,
+  QuoteOff,
+  QuoteOffAndRedirectToParentInputOff
 };
 
 QString GetExpressionForControl(const QString& control_name,
                                 const ciface::Core::DeviceQualifier& control_device,
                                 const ciface::Core::DeviceQualifier& default_device,
-                                Quote quote = Quote::On);
+                                ExpressionType expression_type = ExpressionType::QuoteOn);
 
 QString DetectExpression(QPushButton* button, ciface::Core::DeviceContainer& device_container,
                          const std::vector<std::string>& device_strings,
                          const ciface::Core::DeviceQualifier& default_device,
-                         Quote quote = Quote::On);
+                         ExpressionType expression_type = ExpressionType::QuoteOn);
 
+void TestOutput(QPushButton* button, ciface::Core::DeviceContainer& device_container,
+                ciface::Core::Device* device, std::string output_name);
 void TestOutput(QPushButton* button, OutputReference* reference);
 
 void RemoveSpuriousTriggerCombinations(std::vector<ciface::Core::DeviceContainer::InputDetection>*);
 
 QString BuildExpression(const std::vector<ciface::Core::DeviceContainer::InputDetection>&,
-                        const ciface::Core::DeviceQualifier& default_device, Quote quote);
+                        const ciface::Core::DeviceQualifier& default_device,
+                        ExpressionType expression_type = ExpressionType::QuoteOn);
 
 }  // namespace MappingCommon

--- a/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingIndicator.h
@@ -25,6 +25,7 @@ class QPaintEvent;
 class QTimer;
 
 class CalibrationWidget;
+class MappingWindow;
 
 class MappingIndicator : public QWidget
 {
@@ -41,12 +42,16 @@ public:
   QColor GetTextColor() const;
   QColor GetAltTextColor() const;
   void AdjustGateColor(QColor*);
+  void SetMappingWindow(MappingWindow* mapping_window) { m_mapping_window = mapping_window; }
 
 protected:
   virtual void Draw() {}
+  int GetUpdateFrequency() const;
 
 private:
   void paintEvent(QPaintEvent*) override;
+
+  MappingWindow* m_mapping_window = nullptr;
 };
 
 class SquareIndicator : public MappingIndicator

--- a/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingNumeric.cpp
@@ -20,7 +20,10 @@ MappingDouble::MappingDouble(MappingWidget* parent, ControllerEmu::NumericSettin
 
   connect(this, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           [this, parent](double value) {
-            m_setting.SetValue(value);
+            {
+              const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+              m_setting.SetValue(value);
+            }
             ConfigChanged();
             parent->SaveSettings();
           });
@@ -51,9 +54,11 @@ void MappingDouble::ConfigChanged()
   }
   else
   {
+    // We can't clamp (or at least won't) the value if it came from an expression
     constexpr auto inf = std::numeric_limits<double>::infinity();
     setRange(-inf, inf);
     setButtonSymbols(ButtonSymbols::NoButtons);
+    // Don't disable the button even if users could accidentally lose their expression
     suffix += QString::fromUtf8(" 🎮");
   }
 
@@ -78,7 +83,10 @@ MappingBool::MappingBool(MappingWidget* parent, ControllerEmu::NumericSetting<bo
     setToolTip(tr(ui_description));
 
   connect(this, &QCheckBox::stateChanged, this, [this, parent](int value) {
-    m_setting.SetValue(value != 0);
+    {
+      const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+      m_setting.SetValue(value != 0);
+    }
     ConfigChanged();
     parent->SaveSettings();
   });
@@ -95,7 +103,7 @@ void MappingBool::ConfigChanged()
 
   if (m_setting.IsSimpleValue())
     setText({});
-  else
+  else  // Don't disable the button even if users could accidentally lose their expression
     setText(QString::fromUtf8("🎮"));
 
   setChecked(m_setting.GetValue());

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWidget.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include <QFormLayout>
 #include <QString>
 #include <QWidget>
 
@@ -28,8 +29,6 @@ class EmulatedController;
 class NumericSettingBase;
 }  // namespace ControllerEmu
 
-constexpr int INDICATOR_UPDATE_FREQ = 30;
-
 class MappingWidget : public QWidget
 {
   Q_OBJECT
@@ -39,6 +38,9 @@ public:
   ControllerEmu::EmulatedController* GetController() const;
 
   MappingWindow* GetParent() const;
+
+  bool GetBlockUpdate() const { return m_block_update; }
+  void SetBlockUpdate(bool block_update) { m_block_update = block_update; }
 
   virtual void LoadSettings() = 0;
   virtual void SaveSettings() = 0;
@@ -51,6 +53,8 @@ signals:
 protected:
   int GetPort() const;
 
+  void RefreshSettingsEnabled();
+
   QGroupBox* CreateGroupBox(ControllerEmu::ControlGroup* group);
   QGroupBox* CreateGroupBox(const QString& name, ControllerEmu::ControlGroup* group);
   QGroupBox* CreateControlsBox(const QString& name, ControllerEmu::ControlGroup* group,
@@ -59,5 +63,11 @@ protected:
   QPushButton* CreateSettingAdvancedMappingButton(ControllerEmu::NumericSettingBase& setting);
 
 private:
-  MappingWindow* m_parent;
+  MappingWindow* const m_parent;
+
+protected:
+  std::vector<std::tuple<const ControllerEmu::NumericSettingBase*, QFormLayout::TakeRowResult,
+                         const ControllerEmu::ControlGroup*>>
+      m_edit_condition_numeric_settings;
+  bool m_block_update = false;
 };

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -9,11 +9,11 @@
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QPushButton>
+#include <QScreen>
 #include <QTabWidget>
 #include <QTimer>
 #include <QVBoxLayout>
-
-#include "Core/Core.h"
+#include <QWindow>
 
 #include "Common/CommonPaths.h"
 #include "Common/FileSearch.h"
@@ -68,29 +68,42 @@ MappingWindow::MappingWindow(QWidget* parent, Type type, int port_num)
   SetMappingType(type);
 
   const auto timer = new QTimer(this);
-  connect(timer, &QTimer::timeout, this, [this] {
-    const auto lock = GetController()->GetStateLock();
+  QWidget* parent_window = window();
+  connect(timer, &QTimer::timeout, this, [this, parent_window, timer] {
+    // Draw at the current monitor refresh rate. When emulation is running,
+    // input is often updated at frequencies higher than 60 so this is good to have.
+    QScreen* screen = parent_window->windowHandle()->screen();
+    m_indicator_update_freq = screen->refreshRate();
+    // Note that accuracy is limited to ms so it won't exactly be what we want
+    timer->setInterval(1000 / m_indicator_update_freq);
     emit Update();
   });
 
-  timer->start(1000 / INDICATOR_UPDATE_FREQ);
+  timer->start(1000 / m_indicator_update_freq);
 
-  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
 }
 
 void MappingWindow::CreateDevicesLayout()
 {
   m_devices_layout = new QHBoxLayout();
-  m_devices_box = new QGroupBox(tr("Device"));
+  m_devices_box = new QGroupBox(tr("Default Device"));
   m_devices_combo = new QComboBox();
   m_devices_refresh = new QPushButton(tr("Refresh"));
+  m_detect_all_devices = new QCheckBox(tr("Detect Input From All Devices"));
 
   m_devices_combo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
   m_devices_refresh->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
+  m_devices_combo->setToolTip(
+      tr("Select the default device for this controller.\nThe default device won't need its path "
+         "in front of input/output "
+         "mappings,\nall other devices will (if you want them to work at the same "
+         "time).\nChanging the default device could break your current mappings."));
+
   m_devices_layout->addWidget(m_devices_combo);
   m_devices_layout->addWidget(m_devices_refresh);
+  m_devices_layout->addWidget(m_detect_all_devices);
 
   m_devices_box->setLayout(m_devices_layout);
 }
@@ -117,6 +130,8 @@ void MappingWindow::CreateProfilesLayout()
   m_profiles_layout->addLayout(button_layout);
 
   m_profiles_box->setLayout(m_profiles_layout);
+
+  UpdateProfileButtonState();
 }
 
 void MappingWindow::CreateResetLayout()
@@ -203,8 +218,10 @@ void MappingWindow::UpdateProfileButtonState()
     builtin = profile_path.startsWith(QString::fromStdString(sys_dir));
   }
 
-  m_profiles_save->setEnabled(!builtin);
-  m_profiles_delete->setEnabled(!builtin);
+  bool enable_save_and_delete = !builtin && m_profiles_combo->currentText().length() > 0;
+  m_profiles_save->setEnabled(enable_save_and_delete);
+  m_profiles_delete->setEnabled(enable_save_and_delete);
+  m_profiles_load->setEnabled(m_profiles_combo->currentText().length() > 0);
 }
 
 void MappingWindow::OnSelectProfile(int)
@@ -281,7 +298,6 @@ void MappingWindow::OnLoadProfilePressed()
   m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
   m_controller->UpdateReferences(g_controller_interface);
 
-  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
 }
 
@@ -312,19 +328,29 @@ void MappingWindow::OnSaveProfilePressed()
 
 void MappingWindow::OnSelectDevice(int)
 {
-  if (IsMappingAllDevices())
-    return;
+  const bool no_device = m_devices_combo->currentIndex() == m_devices_combo->count() - 1;
+  {
+    const auto lock = ControllerEmu::EmulatedController::GetStateLock();
+    if (no_device)
+      m_controller->SetDefaultDevice("");
+    // Original string is stored in the "user-data".
+    else
+      m_controller->SetDefaultDevice(m_devices_combo->currentData().toString().toStdString());
+  }
 
-  // Original string is stored in the "user-data".
-  const auto device = m_devices_combo->currentData().toString().toStdString();
+  m_detect_all_devices->setEnabled(!no_device);
 
-  m_controller->SetDefaultDevice(device);
   m_controller->UpdateReferences(g_controller_interface);
 }
 
-bool MappingWindow::IsMappingAllDevices() const
+bool MappingWindow::IsDetectingAllDevices() const
 {
-  return m_devices_combo->currentIndex() == m_devices_combo->count() - 1;
+  // "Detect From All Devices" is blocked from changing when we have no default device as it would
+  // make no sense to do so. Sso we act like it was true (without changing the current value)
+  const auto default_device = m_controller->GetDefaultDevice();
+  if (default_device.name.empty())
+    return true;
+  return m_detect_all_devices->isChecked();
 }
 
 void MappingWindow::RefreshDevices()
@@ -344,10 +370,15 @@ void MappingWindow::OnGlobalDevicesChanged()
     m_devices_combo->addItem(qname, qname);
   }
 
-  m_devices_combo->insertSeparator(m_devices_combo->count());
+  const bool has_any_devices = m_devices_combo->count() > 0;
 
   const auto default_device = m_controller->GetDefaultDevice().ToString();
 
+  bool created_disconnected_default_device = false;
+
+  m_detect_all_devices->setEnabled(!default_device.empty());
+
+  // Try to reselect the default device, add it as a disconnected one if not found
   if (!default_device.empty())
   {
     const auto default_device_index =
@@ -359,15 +390,30 @@ void MappingWindow::OnGlobalDevicesChanged()
     }
     else
     {
-      // Selected device is not currently attached.
+      // Separate disconnected devices from connected ones
+      if (has_any_devices)
+        m_devices_combo->insertSeparator(m_devices_combo->count());
       const auto qname = QString::fromStdString(default_device);
       m_devices_combo->addItem(QLatin1Char{'['} + tr("disconnected") + QStringLiteral("] ") + qname,
                                qname);
       m_devices_combo->setCurrentIndex(m_devices_combo->count() - 1);
+      created_disconnected_default_device = true;
     }
   }
 
-  m_devices_combo->addItem(tr("All devices"));
+  // Separate other devices from this
+  if (m_devices_combo->count() > 0)
+    m_devices_combo->insertSeparator(m_devices_combo->count());
+  m_devices_combo->addItem(tr("None"));
+
+  // Default to "None" if we had no default device or no devices.
+  // Defaulting to the first found device is not necessary because configs already default to it.
+  // Updating references isn't always necessary as it's already called elsewhere on device change.
+  if ((default_device.empty() || !has_any_devices) && !created_disconnected_default_device)
+  {
+    m_devices_combo->setCurrentIndex(m_devices_combo->count() - 1);
+    OnSelectDevice(m_devices_combo->currentIndex());
+  }
 }
 
 void MappingWindow::SetMappingType(MappingWindow::Type type)
@@ -452,6 +498,9 @@ void MappingWindow::SetMappingType(MappingWindow::Type type)
     return;
   }
 
+  // Automatically hide the tab bar if it's redundant (we only have one tab)
+  m_tab_widget->setTabBarAutoHide(true);
+
   widget->LoadSettings();
 
   m_config = widget->GetConfig();
@@ -516,7 +565,6 @@ void MappingWindow::OnDefaultFieldsPressed()
   m_controller->LoadDefaults(g_controller_interface);
   m_controller->UpdateReferences(g_controller_interface);
 
-  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
   emit Save();
 }
@@ -526,14 +574,13 @@ void MappingWindow::OnClearFieldsPressed()
   // Loading an empty inifile section clears everything.
   IniFile::Section sec;
 
-  // Keep the currently selected device.
-  const auto default_device = m_controller->GetDefaultDevice();
   m_controller->LoadConfig(&sec);
-  m_controller->SetDefaultDevice(default_device);
+
+  // Set "None" default device.
+  m_devices_combo->setCurrentIndex(m_devices_combo->count() - 1);
 
   m_controller->UpdateReferences(g_controller_interface);
 
-  const auto lock = GetController()->GetStateLock();
   emit ConfigChanged();
   emit Save();
 }

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.h
@@ -16,8 +16,8 @@ class EmulatedController;
 
 class InputConfig;
 class QComboBox;
+class QCheckBox;
 class QDialogButtonBox;
-class QEvent;
 class QHBoxLayout;
 class QGroupBox;
 class QVBoxLayout;
@@ -51,13 +51,14 @@ public:
 
   int GetPort() const;
   ControllerEmu::EmulatedController* GetController() const;
-  bool IsMappingAllDevices() const;
+  bool IsDetectingAllDevices() const;
   void ShowExtensionMotionTabs(bool show);
+  int GetIndicatorUpdateFrequency() const { return m_indicator_update_freq; }
 
 signals:
   // Emitted when config has changed so widgets can update to reflect the change.
   void ConfigChanged();
-  // Emitted at 30hz for real-time indicators to be updated.
+  // Emitted at indicator_update_freq(Hz) for real-time indicators to be updated.
   void Update();
   void Save();
 
@@ -99,6 +100,7 @@ private:
   QHBoxLayout* m_devices_layout;
   QComboBox* m_devices_combo;
   QPushButton* m_devices_refresh;
+  QCheckBox* m_detect_all_devices;
 
   // Profiles
   QGroupBox* m_profiles_box;
@@ -123,4 +125,6 @@ private:
   Type m_mapping_type;
   const int m_port;
   InputConfig* m_config;
+
+  int m_indicator_update_freq = 60;
 };

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -52,6 +52,7 @@
     <ClCompile Include="Config\CommonControllersWidget.cpp" />
     <ClCompile Include="Config\ControllerInterface\ControllerInterfaceWindow.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.cpp" />
+    <ClCompile Include="Config\ControllerInterface\DualShockUDPClientCalibrationDialog.cpp" />
     <ClCompile Include="Config\ControllerInterface\DualShockUDPClientWidget.cpp" />
     <ClCompile Include="Config\ControllerInterface\ServerStringValidator.cpp" />
     <ClCompile Include="Config\ControllersWindow.cpp" />
@@ -232,6 +233,7 @@
     <QtMoc Include="Config\CommonControllersWidget.h" />
     <QtMoc Include="Config\ControllerInterface\ControllerInterfaceWindow.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientAddServerDialog.h" />
+    <QtMoc Include="Config\ControllerInterface\DualShockUDPClientCalibrationDialog.h" />
     <QtMoc Include="Config\ControllerInterface\DualShockUDPClientWidget.h" />
     <QtMoc Include="Config\ControllerInterface\ServerStringValidator.h" />
     <QtMoc Include="Config\ControllersWindow.h" />

--- a/Source/Core/DolphinQt/Host.cpp
+++ b/Source/Core/DolphinQt/Host.cpp
@@ -85,6 +85,8 @@ void Host::SetMainWindowHandle(void* handle)
   m_main_window_handle = handle;
 }
 
+// Note that even if we are rendering in fullscreen and we are seemingly in the foreground,
+// it doesn't imply the window has focus
 bool Host::GetRenderFocus()
 {
 #ifdef _WIN32
@@ -226,6 +228,7 @@ void Host_RequestRenderWindowSize(int w, int h)
 
 bool Host_UIBlocksControllerState()
 {
+  // TODO: shouldn't this call WantCaptureKeyboard and "controller" as well?
   return ImGui::GetCurrentContext() && ImGui::GetIO().WantCaptureKeyboard;
 }
 

--- a/Source/Core/DolphinQt/HotkeyScheduler.h
+++ b/Source/Core/DolphinQt/HotkeyScheduler.h
@@ -11,6 +11,7 @@
 #include "Common/Flag.h"
 #include "InputCommon/InputProfile.h"
 
+// This isn't exclusively responsible for hotkeys, it's just an old name
 class HotkeyScheduler : public QObject
 {
   Q_OBJECT

--- a/Source/Core/DolphinQt/Settings.cpp
+++ b/Source/Core/DolphinQt/Settings.cpp
@@ -17,7 +17,6 @@
 
 #include "Common/Config/Config.h"
 #include "Common/FileUtil.h"
-#include "Common/StringUtil.h"
 
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
@@ -30,7 +29,6 @@
 #include "DolphinQt/QtUtils/QueueOnObject.h"
 
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
-#include "InputCommon/InputConfig.h"
 
 #include "VideoCommon/NetPlayChatUI.h"
 #include "VideoCommon/NetPlayGolfUI.h"

--- a/Source/Core/InputCommon/CMakeLists.txt
+++ b/Source/Core/InputCommon/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(inputcommon
   ControllerInterface/ControllerInterface.h
   ControllerInterface/CoreDevice.cpp
   ControllerInterface/CoreDevice.h
+  ControllerInterface/InputChannel.h
   ControllerInterface/Wiimote/WiimoteController.cpp
   ControllerInterface/Wiimote/WiimoteController.h
   ControlReference/ControlReference.cpp

--- a/Source/Core/InputCommon/ControlReference/ControlReference.cpp
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.cpp
@@ -2,41 +2,106 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+#include <algorithm>
+
+#include "Core/Host.h"
 
 using namespace ciface::ExpressionParser;
 
-static thread_local bool tls_input_gate = true;
-
-void ControlReference::SetInputGate(bool enable)
+// See Device::FocusFlags for more details
+enum class GateFlags : u8
 {
-  tls_input_gate = enable;
-}
+  // This is always true if the user accepts background input, otherwise
+  // it's only true when the window has focus, similarly to the state below
+  HasFocus = 0x01,
+  // Full focus means the cursor is captured/locked inside the game window.
+  // Ignored if mouse capturing is off. Implies HasFocus
+  HasFullFocus = 0x02,
+  // To ignore some specific inputs temporarily, e.g. mouse down on mouse capture,
+  // that the user pressed to either catch focus or full focus
+  HadFocus = 0x04,
+  HadFullFocus = 0x08,
+  // Fully (force) open, always accept any control. Has priority over any other flag
+  Ignore = 0x10,
+  // Accept calls to ignore (block) input when focus, or full focus, is acquired or lost
+  IgnoreInputOnFocusChanged = 0x20,
 
-bool ControlReference::GetInputGate()
+  // Most or all control will pass in this case.
+  // If none of these are true, the gate is fully closed
+  OpenMask = HasFocus | Ignore,
+  // All control will pass in this case. Remove these flags to block
+  FullOpenMask = HasFocus | HasFullFocus | Ignore,
+  FocusMask = HasFocus | HasFullFocus,
+
+  FocusHistoryMask = HasFocus | HadFocus,
+  FullFocusHistoryMask = HasFullFocus | HadFullFocus
+};
+
+// Gate is "open" by default.
+static thread_local GateFlags tls_gate_flags[u8(ciface::InputChannel::Max)] = {
+    GateFlags::Ignore, GateFlags::Ignore, GateFlags::Ignore, GateFlags::Ignore};
+static_assert(u8(ciface::InputChannel::Max) == 4);  // Add initialization to Ignore
+static thread_local u8 tls_gate_channel = u8(ciface::InputChannel::Host);
+
+// InputReference(s)* never change, they are all created on startup before ever being read.
+// This is here and not made as an Expression (like hotkeys suppression) because it needs to
+// be per thread and it is strictly related to the control gate. It's not per Device::Input
+// because we might want to block any expression.
+// This is not cleared when opening the gate because a thread might update more
+// than one input channel.
+static thread_local std::vector<const InputReference*> tls_blocked_inputs;
+
+GateFlags& GetCurrentGateFlags()
 {
-  return tls_input_gate;
+  return tls_gate_flags[tls_gate_channel];
 }
 
 //
 // UpdateReference
 //
-// Updates a controlreference's binded devices/controls
+// Updates a ControlReference's binded devices/controls
 // need to call this to re-bind a control reference after changing its expression
 //
 void ControlReference::UpdateReference(ciface::ExpressionParser::ControlEnvironment& env)
 {
+  ControllerEmu::EmulatedController::EnsureStateLock();
   if (m_parsed_expression)
-  {
-    m_parsed_expression->UpdateReferences(env);
-  }
+    m_parsed_expression->UpdateReferences(env, IsInput());
+
+  UpdateFocusFlags();
+  UpdateBoundCount();
+  // Don't update the state on controls, let them update in their next natural cycle, as this can be
+  // called by any thread at any time, and it would also break control functions timings.
+}
+
+void ControlReference::UpdateFocusFlags()
+{
+  if (m_parsed_expression)
+    m_cached_focus_flags = u8(m_parsed_expression->GetFocusFlags());
+  else
+    m_cached_focus_flags =
+        IsInput() ? u8(Device::FocusFlags::Default) : u8(Device::FocusFlags::OutputDefault);
+}
+
+void ControlReference::UpdateBoundCount()
+{
+  if (m_parsed_expression)
+    m_cached_bound_count = m_parsed_expression->CountNumControls();
+  else
+    m_cached_bound_count = 0;
 }
 
 int ControlReference::BoundCount() const
 {
-  if (m_parsed_expression)
-    return m_parsed_expression->CountNumControls();
-  else
-    return 0;
+  return m_cached_bound_count;
+}
+
+Device::FocusFlags ControlReference::GetFocusFlags() const
+{
+  return Device::FocusFlags(m_cached_focus_flags.load());
 }
 
 ParseStatus ControlReference::GetParseStatus() const
@@ -44,32 +109,200 @@ ParseStatus ControlReference::GetParseStatus() const
   return m_parse_status;
 }
 
-std::string ControlReference::GetExpression() const
+bool ControlReference::HasExpression() const
 {
+  ControllerEmu::EmulatedController::EnsureStateLock();
+  return m_parsed_expression.get() != nullptr;
+}
+
+const std::string& ControlReference::GetExpression() const
+{
+  ControllerEmu::EmulatedController::EnsureStateLock();
   return m_expression;
 }
 
 std::optional<std::string> ControlReference::SetExpression(std::string expr)
 {
+  ControllerEmu::EmulatedController::EnsureStateLock();
+  // Don't do anything if it hasn't changed. This happens often as we reload configs every time we
+  // open input panels. We parse it again because we need to return the result, which we don't have,
+  // but it's guaranteed to be the same as before.
+  if (m_expression == expr)
+    return ParseExpression(m_expression).description;
+  // If there are any spaces or line breaks, we keep them as they can be used for clarity
   m_expression = std::move(expr);
   auto parse_result = ParseExpression(m_expression);
   m_parse_status = parse_result.status;
   m_parsed_expression = std::move(parse_result.expr);
+
+  // Update input cached values immediately and try to re-apply outputs.
+  // References are missing for now so this is partially useless but also necessary
+  // for numeric settings simplifications in the UI.
+  // The state of inputs is atomic so it's fine, though some places in the code that read
+  // the cached input might get two different values within the same frame, but that's rare
+  // and innocuous enough to be ignored.
+  UpdateFocusFlags();
+  UpdateState();
+  UpdateBoundCount();
+
   return parse_result.description;
 }
 
-ControlReference::ControlReference() : range(1), m_parsed_expression(nullptr)
+void ControlReference::SetCurrentGateOpen()
+{
+  // Keep the previous focus flags for history
+  GateFlags& gate_flags = GetCurrentGateFlags();
+  gate_flags = GateFlags(u8(gate_flags) | u8(GateFlags::Ignore));
+}
+
+bool ControlReference::IsCurrentGateFullyOpen()
+{
+  const GateFlags& gate_flags = GetCurrentGateFlags();
+  return (u8(gate_flags) & u8(GateFlags::FocusMask)) == u8(GateFlags::FocusMask) ||
+         (u8(gate_flags) & u8(GateFlags::Ignore));
+}
+
+void ControlReference::UpdateGate(bool require_focus, bool require_full_focus,
+                                  bool ignore_input_on_focus_changed, ciface::InputChannel channel)
+{
+  // Update the channel of the current thread if it's an accepted value
+  if (channel < ciface::InputChannel::Max)
+  {
+    tls_gate_channel = u8(channel);
+  }
+  u8 gate = 0;
+  GateFlags& gate_flags = GetCurrentGateFlags();
+
+  // If the user accepts background input, controls should pass even if an on screen interface is on
+  if (!require_focus || (Host_RendererHasFocus() && !Host_UIBlocksControllerState()))
+  {
+    gate |= u8(GateFlags::HasFocus);
+
+    if (!require_focus || !require_full_focus || Host_RendererHasFullFocus())
+      gate |= u8(GateFlags::HasFullFocus);
+
+    static_assert(u8(GateFlags::HadFocus) == u8(GateFlags::HasFocus) << 2);
+    static_assert(u8(GateFlags::HadFullFocus) == u8(GateFlags::HasFullFocus) << 2);
+    gate |= (u8(gate_flags) & u8(GateFlags::HasFocus)) << 2;
+    gate |= (u8(gate_flags) & u8(GateFlags::HasFullFocus)) << 2;
+
+    if (require_focus && ignore_input_on_focus_changed)
+      gate |= u8(GateFlags::IgnoreInputOnFocusChanged);
+  }
+  else
+  {
+    // No need to set GateFlags::HadFocus or GateFlags::HadFullFocus
+    // as they are only used when passing from not focus to focus
+  }
+  gate_flags = GateFlags(gate);
+}
+
+// Similar to Filter() but const and doesn't block inputs (just relies on the last update).
+// See Filter() for comments.
+bool ControlReference::PassesGate() const
+{
+  u8 focus_flags = m_cached_focus_flags;
+
+  const GateFlags& gate_flags = GetCurrentGateFlags();
+
+  if ((u8(gate_flags) & u8(GateFlags::Ignore)) ||
+      (focus_flags & u8(Device::FocusFlags::IgnoreFocus)))
+    return true;
+
+  if ((focus_flags & u8(Device::FocusFlags::IgnoreOnFocusChanged)) && IsInput() &&
+      (u8(gate_flags) & u8(GateFlags::IgnoreInputOnFocusChanged)) &&
+      (focus_flags & u8(Device::FocusFlags::RequireFocus)))
+  {
+    std::vector<const InputReference*>::iterator it =
+        std::find(tls_blocked_inputs.begin(), tls_blocked_inputs.end(),
+                  static_cast<const InputReference*>(this));
+    if (it != tls_blocked_inputs.end())
+      return false;
+  }
+  focus_flags &= ~u8(Device::FocusFlags::IgnoreOnFocusChanged);
+
+  return (focus_flags & ~u8(gate_flags)) == 0;
+}
+
+bool ControlReference::Filter(ControlState state)
+{
+  // SettingValue<T> might not have an expression but they don't pass through here
+  if (!m_parsed_expression)
+    return false;
+
+  u8 focus_flags = m_cached_focus_flags;
+  const GateFlags& gate_flags = GetCurrentGateFlags();
+
+  // Return true even if the gate is blocked in some cases, things like battery level
+  // always need to pass
+  if ((u8(gate_flags) & u8(GateFlags::Ignore)) ||
+      (focus_flags & u8(Device::FocusFlags::IgnoreFocus)))
+    return true;
+
+  // This is a rare case (usually skipped) to block inputs that cause a catch focus
+  if ((focus_flags & u8(Device::FocusFlags::IgnoreOnFocusChanged)) && IsInput() &&
+      (u8(gate_flags) & u8(GateFlags::IgnoreInputOnFocusChanged)) &&
+      (focus_flags & u8(Device::FocusFlags::RequireFocus)))
+  {
+    // If the focus up bits are either 1 or 2, then focus has been acquired
+    const u8 focus_bits = u8(GateFlags::FocusHistoryMask) & u8(gate_flags);
+    const bool focus_changed = focus_bits != 0 && focus_bits != u8(GateFlags::FocusHistoryMask);
+    const u8 full_focus_bits = u8(GateFlags::FullFocusHistoryMask) & u8(gate_flags);
+    const bool full_focus_changed =
+        full_focus_bits != 0 && full_focus_bits != u8(GateFlags::FullFocusHistoryMask);
+
+    bool is_blocked = false;
+    std::vector<const InputReference*>::iterator it =
+        std::find(tls_blocked_inputs.begin(), tls_blocked_inputs.end(),
+                  static_cast<const InputReference*>(this));
+    if (it != tls_blocked_inputs.end())
+      is_blocked = true;
+
+    if (((u8(focus_flags) & u8(Device::FocusFlags::RequireFullFocus)) ? full_focus_changed :
+                                                                        focus_changed))
+    {
+      // Block until release if pressed (block threshold is > 0)
+      if (!is_blocked && state > 0.0)
+        tls_blocked_inputs.push_back(static_cast<const InputReference*>(this));
+      return false;
+    }
+
+    if (is_blocked)
+    {
+      if (state > 0.0)
+        return false;
+      // Unblock on release. We should probably do this even if the IgnoreInputOnFocusChanged flag
+      // is off, but it's not worth it (never happens for now)
+      tls_blocked_inputs.erase(it);
+    }
+  }
+  // Exclude this flag from the comparison as it's not actually in GateFlags
+  focus_flags &= ~u8(Device::FocusFlags::IgnoreOnFocusChanged);
+
+  // Remove all the gate flags from the focus flags, if we have no requirements left, we can go on
+  return (focus_flags & ~u8(gate_flags)) == 0;
+}
+
+ControlReference::ControlReference(ControlState range_)
+    : range(range_), default_range(range_), m_parsed_expression(nullptr),
+      m_parse_status(ParseStatus::EmptyExpression)
 {
 }
 
 ControlReference::~ControlReference() = default;
 
-InputReference::InputReference() : ControlReference()
+InputReference::InputReference(ControlState range_) : ControlReference(range_)
+{
+  m_cached_focus_flags = u8(Device::FocusFlags::Default);
+}
+
+IgnoreGateInputReference::IgnoreGateInputReference(ControlState range_) : InputReference(range_)
 {
 }
 
-OutputReference::OutputReference() : ControlReference()
+OutputReference::OutputReference(ControlState range_) : ControlReference(range_)
 {
+  m_cached_focus_flags = u8(Device::FocusFlags::OutputDefault);
 }
 
 bool InputReference::IsInput() const
@@ -81,30 +314,71 @@ bool OutputReference::IsInput() const
   return false;
 }
 
-//
-// InputReference :: State
-//
-// Gets the state of an input reference
-// override function for ControlReference::State ...
-//
-ControlState InputReference::State(const ControlState ignore)
+ControlState ControlReference::GetStateInternal() const
 {
-  if (m_parsed_expression && GetInputGate())
-    return m_parsed_expression->GetValue() * range;
-  return 0.0;
+  return 0;
 }
 
-//
-// OutputReference :: State
-//
-// Set the state of all binded outputs
-// overrides ControlReference::State .. combined them so I could make the GUI simple / inputs ==
-// same as outputs one list
-// I was lazy and it works so watever
-//
-ControlState OutputReference::State(const ControlState state)
+ControlState InputReference::GetStateInternal() const
 {
+  // Check the gate (filter) again, the result of the gate won't change as long as
+  // we check from the same thread.
+  if (PassesGate())
+    return m_cached_state;
+  return 0;
+}
+
+ControlState IgnoreGateInputReference::GetStateInternal() const
+{
+  return m_cached_state;
+}
+
+ControlState OutputReference::GetStateInternal() const
+{
+  ControlState final_state = 0;
+  // Take the sum of all channels
+  for (u8 i = 0; i < u8(ciface::InputChannel::Max); ++i)
+  {
+    final_state += m_cached_states[i];
+  }
+  return final_state * range;
+}
+
+void InputReference::UpdateState()
+{
+  ControllerEmu::EmulatedController::EnsureStateLock();
+  const ControlState state = m_parsed_expression ? (m_parsed_expression->GetValue() * range) : 0;
+  // Every expression can have a different filter (which depends on the gate).
+  // We update the filter now because it can block inputs, though we cache the unfiltered
+  // value so that threads that use a different gate/filter can still retrieve it.
+  // Inputs will only ever be blocked by the gate on the thread that updates them, this isn't
+  // perfect but it works for everything, and allows GetStateInternal() to be const and consistent.
+  Filter(state);
+  m_cached_state = state;
+}
+
+void OutputReference::SetState(ControlState state)
+{
+  if (!Filter())
+    state = 0.0;
+
+  // Useful for keeping the state after we change the expression and also to allow UI and game
+  // to have different values
+  m_cached_states[u8(g_controller_interface.GetCurrentInputChannel())] = state;
+}
+
+void OutputReference::UpdateState()
+{
+  ControllerEmu::EmulatedController::EnsureStateLock();
+
   if (m_parsed_expression)
-    m_parsed_expression->SetValue(state * range);
-  return 0.0;
+    m_parsed_expression->SetValue(GetStateInternal());
+}
+
+void OutputReference::ResetState()
+{
+  for (u8 i = 0; i < u8(ciface::InputChannel::Max); ++i)
+  {
+    m_cached_states[i] = 0;
+  }
 }

--- a/Source/Core/InputCommon/ControlReference/ControlReference.h
+++ b/Source/Core/InputCommon/ControlReference/ControlReference.h
@@ -3,11 +3,15 @@
 
 #pragma once
 
+#include <atomic>
 #include <cmath>
 #include <memory>
 
 #include "InputCommon/ControlReference/ExpressionParser.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
+#include "InputCommon/ControllerInterface/InputChannel.h"
+
+using namespace ciface::Core;
 
 // ControlReference
 //
@@ -16,57 +20,91 @@
 // After being bound to devices and controls with UpdateReference,
 // each one can link to multiple devices and controls
 // when you change a ControlReference's expression,
-// you must use UpdateReference on it to rebind controls
+// you must use UpdateReference on it to rebind controls.
+// Requires EmulatedController::GetStateLock() on: SetState(), UpdateState(),
+// UpdateReference(), SetExpression(), HasExpression() and GetExpression()
 //
-
 class ControlReference
 {
 public:
-  // Note: this is per thread.
-  static void SetInputGate(bool enable);
-  static bool GetInputGate();
-
   virtual ~ControlReference();
-  virtual ControlState State(const ControlState state = 0) = 0;
+  virtual void SetState(ControlState state = 0){};
   virtual bool IsInput() const = 0;
+  // As of now this is used to cache input values and to calculate the expression state only once,
+  // as some of them are are frame based. While on outputs it's used to actually apply them.
+  virtual void UpdateState() = 0;
 
   template <typename T>
-  T GetState();
+  T GetState() const;
 
+  // The control (input/output) gate is per thread per channel, this is because
+  // every input channel needs its own focus history flags, and because
+  // different threads can read input with different focus requirements (e.g. UI vs emulation).
+  // We update the gate once per input frame and cache the results for cheaper retrieval and
+  // consistency. This also sets the current gate channel to the specified one unless we pass Max.
+  // It should always be called between devices update and input reads/caching.
+  static void UpdateGate(bool require_focus, bool require_full_focus = false,
+                         bool ignore_input_on_focus_changed = false,
+                         ciface::InputChannel channel = ciface::InputChannel::Max);
+  static void SetCurrentGateOpen();
+  static bool IsCurrentGateFullyOpen();
+
+  bool PassesGate() const;
+  // Returns the actual number of contols or literals (fixed values) within the expression.
+  // In other words, if this is > 0, the expression has a meaningful value and to control something.
   int BoundCount() const;
+  Device::FocusFlags GetFocusFlags() const;
   ciface::ExpressionParser::ParseStatus GetParseStatus() const;
   void UpdateReference(ciface::ExpressionParser::ControlEnvironment& env);
-  std::string GetExpression() const;
+  bool HasExpression() const;
+  const std::string& GetExpression() const;
 
   // Returns a human-readable error description when the given expression is invalid.
   std::optional<std::string> SetExpression(std::string expr);
 
-  ControlState range;
+  // Range isn't divided by this, it's just for constructors.
+  static constexpr ControlState DEFAULT_RANGE = 1.0;
+
+  // State value multiplier (1 has no effect).
+  // We should probably get rid of this as it's pretty much always pointless,
+  // and it's got terrible naming. The only reasons why it's still here is that
+  // we'd need to convert serialized data if we got rid of it, and it's nice to
+  // have on outputs and input modifiers as it's fairly intuitive there.
+  std::atomic<ControlState> range;
+  // Useful for resetting settings. Usually 1 except for input modifiers.
+  const ControlState default_range;
 
 protected:
-  ControlReference();
+  virtual ControlState GetStateInternal() const;
+  // Returns true if it's allowed to pass. It updates input blocking as well
+  bool Filter(ControlState state = 0);
+  void UpdateFocusFlags();
+  void UpdateBoundCount();
+
+  ControlReference(ControlState range_ = DEFAULT_RANGE);
   std::string m_expression;
   std::unique_ptr<ciface::ExpressionParser::Expression> m_parsed_expression;
-  ciface::ExpressionParser::ParseStatus m_parse_status;
+  // Atomic to avoid NumericSetting<T>::IsSimpleValue() from requiring GetStateLock()
+  std::atomic<ciface::ExpressionParser::ParseStatus> m_parse_status;
+  std::atomic<int> m_cached_bound_count;
+  std::atomic<u8> m_cached_focus_flags;
 };
 
 template <>
-inline bool ControlReference::GetState<bool>()
+inline bool ControlReference::GetState<bool>() const
 {
   // Round to nearest of 0 or 1.
-  return std::lround(State()) > 0;
+  return std::lround(GetStateInternal()) > 0;
 }
-
 template <>
-inline int ControlReference::GetState<int>()
+inline int ControlReference::GetState<int>() const
 {
-  return std::lround(State());
+  return std::lround(GetStateInternal());
 }
-
 template <>
-inline ControlState ControlReference::GetState<ControlState>()
+inline ControlState ControlReference::GetState<ControlState>() const
 {
-  return State();
+  return GetStateInternal();
 }
 
 //
@@ -77,9 +115,26 @@ inline ControlState ControlReference::GetState<ControlState>()
 class InputReference : public ControlReference
 {
 public:
-  InputReference();
+  InputReference(ControlState range_ = DEFAULT_RANGE);
   bool IsInput() const override;
-  ControlState State(const ControlState state) override;
+  // Returns the cached (and filtered) state.
+  ControlState GetStateInternal() const override;
+  void UpdateState() override;
+
+protected:
+  std::atomic<ControlState> m_cached_state;
+};
+
+//
+// IgnoreGateInputReference
+//
+// Control reference for inputs that should ignore focus, like battery level or any settings
+//
+class IgnoreGateInputReference : public InputReference
+{
+public:
+  IgnoreGateInputReference(ControlState range_ = DEFAULT_RANGE);
+  ControlState GetStateInternal() const override;
 };
 
 //
@@ -90,7 +145,19 @@ public:
 class OutputReference : public ControlReference
 {
 public:
-  OutputReference();
+  OutputReference(ControlState range_ = DEFAULT_RANGE);
   bool IsInput() const override;
-  ControlState State(const ControlState state) override;
+  // Returns the sum of the cached (and filtered) states.
+  // Does not require EmulatedController::GetStateLock() but unless it's called with it,
+  // it guarantees no consistency between the atomic m_cached_states.
+  ControlState GetStateInternal() const override;
+  void SetState(ControlState state) override;
+  // The role of UpdateState() in outputs is kind of inverted.
+  // SetState() does the caching, while the update applies them.
+  void UpdateState() override;
+  // Does not apply it. Call UpdateState() after if you want.
+  void ResetState();
+
+protected:
+  std::atomic<ControlState> m_cached_states[u8(ciface::InputChannel::Max)];
 };

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.cpp
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "InputCommon/ControlReference/FunctionExpression.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
+
+#include "Common/Common.h"
+#include "Common/MathUtil.h"
+#include "Core/Core.h"
+#include "Core/HW/VideoInterface.h"
+#include "Core/Host.h"
 
 #include <algorithm>
 #include <chrono>
@@ -12,44 +19,90 @@ namespace ciface::ExpressionParser
 using Clock = std::chrono::steady_clock;
 using FSec = std::chrono::duration<ControlState>;
 
-// usage: toggle(toggle_state_input, [clear_state_input])
-class ToggleExpression : public FunctionExpression
+// usage: min(expression1, expression2)
+class MinExpression : public FunctionExpression
 {
 private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
-    // Optional 2nd argument for clearing state:
-    if (args.size() == 1 || args.size() == 2)
+    if (args.size() == 2)
       return ArgumentsAreValid{};
     else
-      return ExpectedArguments{"toggle_state_input, [clear_state_input]"};
+      return ExpectedArguments{"expression1, expression2"};
   }
 
   ControlState GetValue() const override
   {
-    const ControlState inner_value = GetArg(0).GetValue();
+    const ControlState val1 = GetArg(0).GetValue();
+    const ControlState val2 = GetArg(1).GetValue();
 
-    if (inner_value < CONDITION_THRESHOLD)
-    {
-      m_released = true;
-    }
-    else if (m_released && inner_value > CONDITION_THRESHOLD)
-    {
-      m_released = false;
-      m_state ^= true;
-    }
+    return std::min(val1, val2);
+  }
+};
 
-    if (2 == GetArgCount() && GetArg(1).GetValue() > CONDITION_THRESHOLD)
-    {
-      m_state = false;
-    }
-
-    return m_state;
+// usage: max(expression1, expression2)
+class MaxExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression1, expression2"};
   }
 
-  mutable bool m_released{};
-  mutable bool m_state{};
+  ControlState GetValue() const override
+  {
+    const ControlState val1 = GetArg(0).GetValue();
+    const ControlState val2 = GetArg(1).GetValue();
+
+    return std::max(val1, val2);
+  }
+};
+
+// usage: minus(expression)
+class UnaryMinusExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression"};
+  }
+
+  ControlState GetValue() const override
+  {
+    // Subtraction for clarity:
+    return 0.0 - GetArg(0).GetValue();
+  }
+};
+
+// usage: pow(base, exponent)
+class PowExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"base, exponent"};
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState val1 = GetArg(0).GetValue();
+    const ControlState val2 = GetArg(1).GetValue();
+
+    return std::pow(val1, val2);
+  }
 };
 
 // usage: not(expression)
@@ -200,63 +253,6 @@ private:
   ControlState GetValue() const override { return std::sqrt(GetArg(0).GetValue()); }
 };
 
-// usage: pow(base, exponent)
-class PowExpression : public FunctionExpression
-{
-private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
-  {
-    if (args.size() == 2)
-      return ArgumentsAreValid{};
-    else
-      return ExpectedArguments{"base, exponent"};
-  }
-
-  ControlState GetValue() const override
-  {
-    return std::pow(GetArg(0).GetValue(), GetArg(1).GetValue());
-  }
-};
-
-// usage: min(a, b)
-class MinExpression : public FunctionExpression
-{
-private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
-  {
-    if (args.size() == 2)
-      return ArgumentsAreValid{};
-    else
-      return ExpectedArguments{"a, b"};
-  }
-
-  ControlState GetValue() const override
-  {
-    return std::min(GetArg(0).GetValue(), GetArg(1).GetValue());
-  }
-};
-
-// usage: max(a, b)
-class MaxExpression : public FunctionExpression
-{
-private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
-  {
-    if (args.size() == 2)
-      return ArgumentsAreValid{};
-    else
-      return ExpectedArguments{"a, b"};
-  }
-
-  ControlState GetValue() const override
-  {
-    return std::max(GetArg(0).GetValue(), GetArg(1).GetValue());
-  }
-};
-
 // usage: clamp(value, min, max)
 class ClampExpression : public FunctionExpression
 {
@@ -276,49 +272,6 @@ private:
   }
 };
 
-// usage: timer(seconds)
-class TimerExpression : public FunctionExpression
-{
-private:
-  ArgumentValidation
-  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
-  {
-    if (args.size() == 1)
-      return ArgumentsAreValid{};
-    else
-      return ExpectedArguments{"seconds"};
-  }
-
-  ControlState GetValue() const override
-  {
-    const auto now = Clock::now();
-    const auto elapsed = now - m_start_time;
-
-    const ControlState val = GetArg(0).GetValue();
-
-    ControlState progress = std::chrono::duration_cast<FSec>(elapsed).count() / val;
-
-    if (std::isinf(progress) || progress < 0.0)
-    {
-      // User configured a non-positive timer. Reset the timer and return 0.0.
-      progress = 0.0;
-      m_start_time = now;
-    }
-    else if (progress >= 1.0)
-    {
-      const ControlState reset_count = std::floor(progress);
-
-      m_start_time += std::chrono::duration_cast<Clock::duration>(FSec(val * reset_count));
-      progress -= reset_count;
-    }
-
-    return progress;
-  }
-
-private:
-  mutable Clock::time_point m_start_time = Clock::now();
-};
-
 // usage: if(condition, true_expression, false_expression)
 class IfExpression : public FunctionExpression
 {
@@ -334,34 +287,378 @@ private:
 
   ControlState GetValue() const override
   {
-    return (GetArg(0).GetValue() > CONDITION_THRESHOLD) ? GetArg(1).GetValue() :
-                                                          GetArg(2).GetValue();
+    const ControlState true_state = GetArg(1).GetValue();
+    const ControlState false_state = GetArg(2).GetValue();
+    return (GetArg(0).GetValue() > CONDITION_THRESHOLD) ? true_state : false_state;
   }
 };
 
-// usage: minus(expression)
-class UnaryMinusExpression : public FunctionExpression
+// usage: interval(delay_frames, duration_frames)
+class IntervalExpression : public FunctionExpression
 {
 private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
-    if (args.size() == 1)
+    if (args.size() == 2)
       return ArgumentsAreValid{};
     else
-      return ExpectedArguments{"expression"};
+      return ExpectedArguments{"delay_frames, duration_frames"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans(
+        "Returns 1 for \"duration_frames\" every \"delay_frames\" (while it keeps counting them)");
   }
 
   ControlState GetValue() const override
   {
-    // Subtraction for clarity:
-    return 0.0 - GetArg(0).GetValue();
+    const u32 delay_frames = u32(std::max(GetArg(0).GetValue() + 0.5, 0.0));
+    const u32 duration_frames = u32(std::max(GetArg(1).GetValue() + 0.5, 0.0));
+
+    if (duration_frames_counter > 0)
+    {
+      --duration_frames_counter;
+    }
+
+    if (delay_frames_counter >= delay_frames)
+    {
+      duration_frames_counter = duration_frames;
+      delay_frames_counter = 0;
+    }
+    else
+    {
+      delay_frames_counter++;
+    }
+
+    return duration_frames_counter > 0;
   }
+
+  mutable u32 delay_frames_counter = 0;
+  mutable u32 duration_frames_counter = 0;
+};
+
+// usage: sequence(input, value_0, value_1, ...)
+class SequenceExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() >= 3)  // Enforce at least two values, use onPress() otherwise
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, value_0, value_1, ..."};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Will start playing back the specified sequence (frame by frame) every time the "
+                  "input is pressed");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    // We need to retrieve all the states for consistency, though for this
+    // we should "enforce" literal expressions which don't have a state
+    std::vector<ControlState> sequence;
+    const u32 sequence_length = GetArgCount() - 1;
+    sequence.reserve(sequence_length);
+    for (u32 i = 1; i < GetArgCount(); ++i)
+      sequence.push_back(GetArg(i).GetValue());
+
+    if (input > CONDITION_THRESHOLD && !m_pressed)
+    {
+      m_started = true;
+      m_index = 0;
+    }
+    m_pressed = input > CONDITION_THRESHOLD;
+
+    if (!m_started)
+      return 0;
+
+    if (m_index >= sequence_length)
+    {
+      m_started = false;
+      return 0;
+    }
+
+    return sequence[m_index++];  // Increase the index
+  }
+
+  mutable u32 m_index = 0;
+  mutable bool m_pressed = false;
+  mutable bool m_started = false;
+};
+
+// usage: record(input, record_input, playback_input)
+class RecordExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 3)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, record_input, playback_input"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("It will record \"input\" while \"record_input\" is held down, and "
+                  "playback when \"playback_input\" is pressed. \"input\" is passed through "
+                  "otherwise. Recordings are not saved");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    const ControlState record_input = GetArg(1).GetValue();
+    const ControlState playback_input = GetArg(2).GetValue();
+
+    if (record_input > CONDITION_THRESHOLD && !m_record_pressed)
+    {
+      m_recording = true;
+      m_playing_back = false;
+      m_recorded_states.clear();
+    }
+    else if (record_input <= CONDITION_THRESHOLD && m_record_pressed)
+    {
+      m_recording = false;
+    }
+    m_record_pressed = record_input > CONDITION_THRESHOLD;
+
+    if (!m_recording && m_recorded_states.size() > 0 && playback_input > CONDITION_THRESHOLD &&
+        !m_playback_pressed)
+    {
+      m_playing_back = true;
+      m_index = 0;
+    }
+    m_playback_pressed = playback_input > CONDITION_THRESHOLD;
+
+    if (m_recording)
+    {
+      m_recorded_states.push_back(input);
+    }
+    else if (m_playing_back)
+    {
+      ++m_index;
+      if (m_index >= m_recorded_states.size())
+      {
+        m_playing_back = false;
+      }
+      return m_recorded_states[m_index - 1];
+    }
+    return input;
+  }
+
+  mutable std::vector<ControlState> m_recorded_states;
+  mutable u32 m_index = 0;
+  mutable bool m_record_pressed = false;
+  mutable bool m_playback_pressed = false;
+  mutable bool m_recording = false;
+  mutable bool m_playing_back = false;
+};
+
+// usage: lag(input, lag_frames)
+class LagExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, lag_frames"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Will lag (delay) the input by \"lag_frames\"");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    const size_t lag_frames = size_t(std::max(GetArg(1).GetValue() + 0.5, 0.0));
+
+    m_cached_states.reserve(lag_frames + 1);
+
+    while (m_cached_states.size() < lag_frames)
+    {
+      m_cached_states.push_back(0);
+    }
+
+    m_cached_states.insert(m_cached_states.begin(), input);
+
+    const ControlState oldest_state = m_cached_states[lag_frames];
+    while (m_cached_states.size() > lag_frames)
+    {
+      m_cached_states.pop_back();
+    }
+
+    return oldest_state;
+  }
+
+  mutable std::vector<ControlState> m_cached_states;
+};
+
+// usage: average(input, frames)
+class AverageExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, frames"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Returns the average of the input over the specified number of frames");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    // Note that if you increase this at runtime, we won't have the corresponding values
+    const size_t frames = size_t(std::max(GetArg(1).GetValue() + 0.5, 1.0));
+
+    m_cached_states.reserve(frames + 1);
+
+    m_cached_states.insert(m_cached_states.begin(), input);
+    while (m_cached_states.size() > frames)
+    {
+      m_cached_states.pop_back();
+    }
+
+    ControlState sum = 0.0;
+    for (ControlState cached_state : m_cached_states)
+    {
+      sum += cached_state;
+    }
+
+    return sum / std::min(m_cached_states.size(), frames);
+  }
+
+  mutable std::vector<ControlState> m_cached_states;
+};
+
+// usage: sum(input, frames)
+// E.g. GC SerialInterface updates at twice the video refresh rate of the game, it's very unlikely
+// that games will consider/read both inputs so we sum the last two to not miss values
+class SumExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, frames"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Returns the sum of the input over the specified number of frames. Use "
+                  "this on relative inputs to avoid losing values not read by the game");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    // Note that if you increase this at runtime, we won't have the corresponding values
+    const size_t frames = size_t(std::max(GetArg(1).GetValue() + 0.5, 1.0));
+
+    m_cached_states.reserve(frames + 1);
+
+    m_cached_states.insert(m_cached_states.begin(), input);
+    while (m_cached_states.size() > frames)
+    {
+      m_cached_states.pop_back();
+    }
+
+    ControlState sum = 0.0;
+    for (ControlState cached_state : m_cached_states)
+    {
+      sum += cached_state;
+    }
+    return sum;
+  }
+
+  mutable std::vector<ControlState> m_cached_states;
+};
+
+// usage: timer(seconds, reset = false)
+class TimerExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1 || args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"seconds, reset = false"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Returns the progress to reach the specified time (you can change it on the go "
+                  "to change the progress speed). Loops around once reached");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState seconds = GetArg(0).GetValue();
+    const bool reset = GetArgCount() == 2 ? (GetArg(1).GetValue() > CONDITION_THRESHOLD) : false;
+
+    if (reset)
+    {
+      m_progress = 0.0;
+    }
+
+    if (seconds <= 0.0)
+    {
+      // User configured a non-positive timer. Reset the timer and return 0.
+      m_progress = 0.0;
+      m_has_started = false;
+      return m_progress;
+    }
+
+    // The very first frame needs to return 0
+    if (m_has_started)
+      m_progress += ControllerInterface::GetCurrentInputDeltaSeconds() / seconds;
+
+    if (m_progress > 1.0)
+    {
+      const double reset_count = std::floor(m_progress);
+      m_progress -= reset_count;
+    }
+    else if (m_progress <= 0.0)
+    {
+      m_has_started = true;
+    }
+
+    return m_progress;
+  }
+
+  mutable bool m_has_started = false;
+  mutable double m_progress = 0.0;
 };
 
 // usage: deadzone(input, amount)
 class DeadzoneExpression : public FunctionExpression
 {
+private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
@@ -379,10 +676,152 @@ class DeadzoneExpression : public FunctionExpression
   }
 };
 
+// usage: antiDeadzone(input, amount)
+class AntiDeadzoneExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, amount"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Goes against a game built in deadzone, like if it will treat 0.2 (amount) as "
+                  "0, but will treat 0.3 as 0.125. It should be applied after deadzone");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState val = GetArg(0).GetValue();
+    const ControlState anti_deadzone = GetArg(1).GetValue();
+    // We don't want to return a min of anti_deadzone if our val is 0.
+    // It fixes the problem where 2 opposite axes (e.g. R stick X+ and R stick Y-) have the same
+    // anti deadzone expression so they would cancel each other out if we didn't check for this.
+    if (val == 0.0)
+      return 0;
+    const ControlState abs_val = std::abs(val);
+    return std::copysign(anti_deadzone + abs_val * (1.0 - anti_deadzone), val);
+  }
+};
+
+// usage: bezierCurve(input, x1, x2)
+class BezierCurveExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 3)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, x1, x2"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("2 control points bezier. Basically just a fancy \"remap\"in one dimension. "
+                  "Useful to go against games analog stick response curve when using the"
+                  "mouse as as axis, or when games have a linear response curve to an analog stick"
+                  " and you'd like to change it. Mostly used on the x axis (left/right)");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState val = GetArg(0).GetValue();
+    const ControlState x1 = GetArg(1).GetValue();
+    const ControlState x2 = GetArg(2).GetValue();
+
+    const ControlState t = std::abs(val);
+    const ControlState t2 = t * t;
+    const ControlState t3 = t2 * t;
+    const ControlState u = 1.0 - t;
+    const ControlState u2 = u * u;
+
+    // Don't clamp between 0 and 1.
+    // Formula actually is like below but control point x0 and x3 are 0 and 1.
+    // u3*x0 + 3*u2*t*x1 + 3*u*t2*x2 + t3*x3
+    const ControlState bezier = (3.0 * u2 * t * x1) + (3.0 * u * t2 * x2) + t3;
+    return std::copysign(bezier, val);
+  }
+};
+
+// usage: acceleration(input, max_acc_time, acc, min_time_input, min_acc_input, max_acc_input = 1)
+// The way this work is by "predicting" the acceleration the game would have with time, and
+// increasing the input value so you won't feel any acceleration, the drawback is that you might see
+// some velocity snapping, and this doesn't work when passing in a maxed out input of course. An
+// alternative approach would be to actually try to shrink the input as time passed, to counteract
+// the acceleration, but that would strongly limit the max output. Use after AntiDeadzone and
+// BezierCurve. In some games acceleration is only on the X axis.
+class AntiAccelerationExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 5 || args.size() == 6)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, max_acc_time, acc, min_time_input, "
+                               "min_acc_input, max_acc_input = 1"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans(
+        "Useful when using the mouse as an axis and you don't want the game to gradually "
+        "accelerate its response with time. It should help in keeping a response curve closer to "
+        "1:1 (linear)");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState val = GetArg(0).GetValue();
+    // After this time, the game won't accelerate anymore
+    const ControlState max_acc_time = 1.0 + GetArg(1).GetValue();
+    // Just a random (guessed) value to accelerate our input while we are contrasting the
+    // acceleration that is happening in the game
+    const ControlState acc = GetArg(2).GetValue();
+    // Elapsed time, which influences the output, is counted if the input is >= than this value
+    const ControlState min_time_input = GetArg(3).GetValue();
+    // Input at which the game would start accelerating
+    const ControlState min_acc_input = GetArg(4).GetValue();
+    // Input at which the game would reach the maximum acceleration (usually 1)
+    const ControlState max_acc_input = GetArgCount() == 6 ? GetArg(5).GetValue() : 1.0;
+
+    const ControlState abs_val = std::abs(val);
+    if (abs_val < min_acc_input)
+    {
+      m_elapsed = 0.0;
+      return val;
+    }
+
+    const ControlState diff = max_acc_input - min_acc_input;
+    const ControlState acc_alpha =
+        diff != 0.0 ? std::clamp((abs_val - min_acc_input) / diff, 0.0, 1.0) : 1.0;
+    const ControlState time_alpha = std::min((max_acc_time - m_elapsed) / max_acc_time, 0.0);
+
+    const ControlState multiplier = MathUtil::Lerp(1.0, acc * acc_alpha, time_alpha * time_alpha);
+
+    if (abs_val >= min_time_input)
+      m_elapsed += ControllerInterface::GetCurrentInputDeltaSeconds();
+    else
+      m_elapsed = 0.0;
+
+    return std::copysign(abs_val * multiplier, val);
+  }
+
+  mutable double m_elapsed = 0.0;
+};
+
 // usage: smooth(input, seconds_up, seconds_down = seconds_up)
-// seconds is seconds to change from 0.0 to 1.0
 class SmoothExpression : public FunctionExpression
 {
+private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
@@ -392,41 +831,261 @@ class SmoothExpression : public FunctionExpression
       return ExpectedArguments{"input, seconds_up, seconds_down = seconds_up"};
   }
 
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Gradually moves its internal value toward its target value (input). It asks for "
+                  "the times to go between 0 and 1. Can be used to simulate a relative axis");
+  }
+
   ControlState GetValue() const override
   {
-    const auto now = Clock::now();
-    const auto elapsed = now - m_last_update;
-    m_last_update = now;
-
     const ControlState desired_value = GetArg(0).GetValue();
 
     const ControlState smooth_up = GetArg(1).GetValue();
     const ControlState smooth_down = GetArgCount() == 3 ? GetArg(2).GetValue() : smooth_up;
 
-    const ControlState smooth = (desired_value < m_value) ? smooth_down : smooth_up;
-    const ControlState max_move = std::chrono::duration_cast<FSec>(elapsed).count() / smooth;
+    const ControlState smooth = (desired_value < m_state) ? smooth_down : smooth_up;
+    const ControlState max_move = ControllerInterface::GetCurrentInputDeltaSeconds() / smooth;
 
     if (std::isinf(max_move))
     {
-      m_value = desired_value;
+      m_state = desired_value;
     }
     else
     {
-      const ControlState diff = desired_value - m_value;
-      m_value += std::copysign(std::min(max_move, std::abs(diff)), diff);
+      const ControlState diff = desired_value - m_state;
+      m_state += std::copysign(std::min(max_move, std::abs(diff)), diff);
     }
 
-    return m_value;
+    return m_state;
   }
 
-private:
-  mutable ControlState m_value = 0.0;
-  mutable Clock::time_point m_last_update = Clock::now();
+  mutable ControlState m_state = 0;
 };
 
-// usage: hold(input, seconds)
-class HoldExpression : public FunctionExpression
+// usage: toggle(input, [clear])
+class ToggleExpression : public FunctionExpression
 {
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    // Optional 2nd argument for clearing state:
+    if (args.size() == 1 || args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, [clear]"};
+  }
+
+  const char* GetDescription(bool for_input) const override { return _trans("Toggle on press"); }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+
+    if (input > CONDITION_THRESHOLD)
+    {
+      if (!m_pressed)
+      {
+        m_pressed = true;
+        m_state ^= true;
+      }
+    }
+    else
+    {
+      m_pressed = false;
+    }
+
+    if (GetArgCount() == 2 && GetArg(1).GetValue() > CONDITION_THRESHOLD)
+      m_state = false;
+
+    return m_state;
+  }
+
+  mutable bool m_pressed = false;
+  mutable bool m_state = false;
+};
+
+// usage: onPress(input, duration_frames = 1)
+class OnPressExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() >= 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, duration_frames = 1"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return "Returns 1 when the input has been pressed, for "
+           "the specified number of frames";
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    const u32 duration_frames =
+        GetArgCount() >= 2 ? u32(std::max(GetArg(1).GetValue() + 0.5, 0.0)) : 1;
+
+    if (m_frames_left > 0)
+      m_frames_left--;
+
+    const bool was_pressed = m_pressed;
+    m_pressed = input > CONDITION_THRESHOLD;
+
+    // Start again on every new press, don't restart on release
+    if (!was_pressed && m_pressed)
+      m_frames_left = duration_frames;
+
+    return m_frames_left > 0;
+  }
+
+  mutable bool m_pressed = false;
+  mutable u32 m_frames_left = 0;
+};
+
+// usage: onRelease(input, duration_frames = 1)
+class OnReleaseExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() >= 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, duration_frames = 1"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return "Returns 1 when the input has been released, for "
+           "the specified number of frames";
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    const u32 duration_frames =
+        GetArgCount() >= 2 ? u32(std::max(GetArg(1).GetValue() + 0.5, 0.0)) : 1;
+
+    if (m_frames_left > 0)
+      m_frames_left--;
+
+    const bool was_pressed = m_pressed;
+    m_pressed = input > CONDITION_THRESHOLD;
+
+    // Start again on every new release, don't restart on press
+    if (was_pressed && !m_pressed)
+      m_frames_left = duration_frames;
+
+    return m_frames_left > 0;
+  }
+
+  mutable bool m_pressed = false;
+  mutable u32 m_frames_left = 0;
+};
+
+// usage: onChange(input, duration_frames = 1)
+class OnChangeExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() >= 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, duration_frames = 1"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return "Returns 1 when the input detection threshold has changed from the previous value, for "
+           "the specified number of frames";
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    const u32 duration_frames =
+        GetArgCount() >= 2 ? u32(std::max(GetArg(1).GetValue() + 0.5, 0.0)) : 1;
+
+    if (m_frames_left > 0)
+      m_frames_left--;
+
+    const bool was_pressed = m_pressed;
+    m_pressed = input > CONDITION_THRESHOLD;
+
+    // Start again on every new press or release
+    if (was_pressed != m_pressed)
+      m_frames_left = duration_frames;
+
+    return m_frames_left > 0;
+  }
+
+  mutable bool m_pressed = false;
+  mutable u32 m_frames_left = 0;
+};
+
+// usage: cache(expression, condition)
+// Note that resetting/releasing the condition input does not reset the cached value
+class CacheExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression, condition"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    if (for_input)
+    {
+      return _trans("Caches and returns the input when the condition is true, returns the "
+                    "cached value when the condition is false");
+    }
+    return _trans("Sets and caches the value when the condition is true, keeps settings the cached "
+                  "value when the condition is false");
+  }
+
+  ControlState GetValue() const override
+  {
+    const ControlState input = GetArg(0).GetValue();
+    const ControlState condition = GetArg(1).GetValue();
+
+    if (condition > CONDITION_THRESHOLD)
+      m_state = input;
+
+    return m_state;
+  }
+
+  void SetValue(ControlState value) override
+  {
+    const ControlState condition = GetArg(1).GetValue();
+
+    if (condition > CONDITION_THRESHOLD)
+      m_state = value;
+
+    GetArg(0).SetValue(m_state);
+  }
+
+  mutable ControlState m_state = 0;
+};
+
+// usage: onHold(input, seconds)
+// Use real world time for this one as it makes more sense
+class OnHoldExpression : public FunctionExpression
+{
+private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
@@ -436,13 +1095,19 @@ class HoldExpression : public FunctionExpression
       return ExpectedArguments{"input, seconds"};
   }
 
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Returns true after being held for the specified amount of time, until released");
+  }
+
   ControlState GetValue() const override
   {
     const auto now = Clock::now();
 
     const ControlState input = GetArg(0).GetValue();
+    const ControlState seconds = GetArg(1).GetValue();
 
-    if (input < CONDITION_THRESHOLD)
+    if (input <= CONDITION_THRESHOLD)
     {
       m_state = false;
       m_start_time = Clock::now();
@@ -451,21 +1116,24 @@ class HoldExpression : public FunctionExpression
     {
       const auto hold_time = now - m_start_time;
 
-      if (std::chrono::duration_cast<FSec>(hold_time).count() >= GetArg(1).GetValue())
+      if (std::chrono::duration_cast<FSec>(hold_time).count() >= seconds)
         m_state = true;
     }
 
     return m_state;
   }
 
-private:
   mutable bool m_state = false;
   mutable Clock::time_point m_start_time = Clock::now();
 };
 
-// usage: tap(input, seconds, taps=2)
-class TapExpression : public FunctionExpression
+// usage: onTap(input, seconds, taps = 2)
+// Use real world time for this one as it makes more sense.
+// It would be nice to add a setting to restart the detection time on every tap,
+// for more flexibility
+class OnTapExpression : public FunctionExpression
 {
+private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
@@ -473,6 +1141,12 @@ class TapExpression : public FunctionExpression
       return ArgumentsAreValid{};
     else
       return ExpectedArguments{"input, seconds, taps = 2"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Double+ tap detection within the specified time from the first tap. Keeps "
+                  "returning 1 until you release the last tap");
   }
 
   ControlState GetValue() const override
@@ -484,55 +1158,57 @@ class TapExpression : public FunctionExpression
     const ControlState input = GetArg(0).GetValue();
     const ControlState seconds = GetArg(1).GetValue();
 
-    const bool is_time_up = elapsed > seconds;
+    const bool is_time_up = elapsed >= seconds;
 
-    const u32 desired_taps = GetArgCount() == 3 ? u32(GetArg(2).GetValue() + 0.5) : 2;
+    const u32 desired_taps =
+        GetArgCount() == 3 ? u32(std::max(GetArg(2).GetValue() + 0.5, 0.0)) : 2;
 
-    if (input < CONDITION_THRESHOLD)
+    if (input <= CONDITION_THRESHOLD)
     {
       m_released = true;
 
+      // Reset taps if enough time has passed from the first one
       if (m_taps > 0 && is_time_up)
-      {
         m_taps = 0;
-      }
+
+      return false;
     }
-    else
+
+    if (m_released)
     {
-      if (m_released)
-      {
-        if (!m_taps)
-        {
-          m_start_time = now;
-        }
+      if (m_taps == 0)
+        m_start_time = now;
 
-        ++m_taps;
-        m_released = false;
-      }
-
-      return desired_taps == m_taps;
+      ++m_taps;
+      m_released = false;
     }
 
-    return 0.0;
+    return desired_taps == m_taps;
   }
 
-private:
   mutable bool m_released = true;
   mutable u32 m_taps = 0;
   mutable Clock::time_point m_start_time = Clock::now();
 };
 
-// usage: relative(input, speed, [max_abs_value, [shared_state]])
-// speed is max movement per second
-class RelativeExpression : public FunctionExpression
+// usage: sharedRelative(input, speed = 0, max_abs_value = 1, [shared_state])
+class SharedRelativeExpression : public FunctionExpression
 {
+private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
-    if (args.size() >= 2 && args.size() <= 4)
+    if (args.size() >= 1 && args.size() <= 4)
       return ArgumentsAreValid{};
     else
-      return ExpectedArguments{"input, speed, [max_abs_value, [shared_state]]"};
+      return ExpectedArguments{"input, speed = 0, max_abs_value = 1, [shared_state]"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans(
+        "Adds the value of an input to a state, multiplied by a speed per second if it's > 0. You"
+        " can add a shared state with $unique_name to link functions from two opposite mappings");
   }
 
   ControlState GetValue() const override
@@ -550,57 +1226,103 @@ class RelativeExpression : public FunctionExpression
     // This mapping (for down) returns the negative value clamped between 0.0 and 1.0
     // (Adjustments created by `Down` are applied negatively to the shared state)
     //  relative(`Down`, 2.0, -1.0, $y)
-
-    const auto now = Clock::now();
-
-    if (GetArgCount() >= 4)
-      m_state = GetArg(3).GetValue();
-
-    const auto elapsed = std::chrono::duration_cast<FSec>(now - m_last_update).count();
-    m_last_update = now;
+    //
+    // Note that this won't work if directly mapped to a single button as it won't go back.
 
     const ControlState input = GetArg(0).GetValue();
-    const ControlState speed = GetArg(1).GetValue();
+    const ControlState speed = (GetArgCount() >= 2) ? GetArg(1).GetValue() : 0.0;
 
     const ControlState max_abs_value = (GetArgCount() >= 3) ? GetArg(2).GetValue() : 1.0;
 
-    const ControlState max_move = input * elapsed * speed;
-    const ControlState diff_from_zero = std::abs(0.0 - m_state);
+    // This will likely (hopefully) be a VariableExpression.
+    if (GetArgCount() >= 4)
+      m_state = GetArg(3).GetValue();
+
+    const ControlState max_move =
+        input * (speed > 0.f ? (ControllerInterface::GetCurrentInputDeltaSeconds() * speed) : 1.0);
+    const ControlState diff_from_zero = std::abs(m_state);
     const ControlState diff_from_max = std::abs(max_abs_value - m_state);
 
     m_state += std::min(std::max(max_move, -diff_from_zero), diff_from_max) *
                std::copysign(1.0, max_abs_value);
 
+    // Break const correctness but GetValue() is kind of meant like an update method now
     if (GetArgCount() >= 4)
       const_cast<Expression&>(GetArg(3)).SetValue(m_state);
 
     return std::max(0.0, m_state * std::copysign(1.0, max_abs_value));
   }
 
-private:
-  mutable ControlState m_state = 0.0;
-  mutable Clock::time_point m_last_update = Clock::now();
+  mutable ControlState m_state = 0;
 };
 
-// usage: pulse(input, seconds)
-class PulseExpression : public FunctionExpression
+// usage: relativeToSpeed(input)
+// Input polling is not done at irregular intervals, both in real/world time,
+// and in emulation time (irregular only on the SI).
+// Meaning that relative axis movement would be vastly different between input frames,
+// so we need to normalize it.
+// Note that sometimes 2 input updates are so close to each other that relative axes
+// might not have had time to move precisely, so our output won't be linear with their speed.
+class RelativeToSpeedExpression : public FunctionExpression
 {
+private:
   ArgumentValidation
   ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
   {
-    if (args.size() == 2)
+    if (args.size() == 1)
       return ArgumentsAreValid{};
     else
-      return ExpectedArguments{"input, seconds"};
+      return ExpectedArguments{"input"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Turns a relative axis into a rate of change (speed). Can be used to map a "
+                  "mouse axis to an analog stick for example");
   }
 
   ControlState GetValue() const override
   {
-    const auto now = Clock::now();
+    const ControlState base_value = GetArg(0).GetValue();
+    // This normalizes the values by:
+    // -the video refresh rate (50 or 60)
+    // -the emulation target speed
+    // -the emulation achieved speed
+    // -the real time oscillations between input polling
+    return base_value *
+           (ControllerInterface::GetTargetInputDeltaSeconds() /
+            ControllerInterface::GetCurrentRealInputDeltaSeconds()) /
+           double(ControllerInterface::GetInputUpdatesPerTarget());
+  }
+};
 
+// usage: pulse(input, seconds, accumulate = true)
+class PulseExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2 || args.size() == 3)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"input, seconds, accumulate = true"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Keeps the value true for \"seconds\" (increasingly if asked) every time the "
+                  "input starts being true");
+  }
+
+  ControlState GetValue() const override
+  {
     const ControlState input = GetArg(0).GetValue();
+    const ControlState seconds = GetArg(1).GetValue();
+    const bool accumulate =
+        GetArgCount() == 3 ? (GetArg(2).GetValue() > CONDITION_THRESHOLD) : true;
 
-    if (input < CONDITION_THRESHOLD)
+    if (input <= CONDITION_THRESHOLD)
     {
       m_released = true;
     }
@@ -608,39 +1330,290 @@ class PulseExpression : public FunctionExpression
     {
       m_released = false;
 
-      const auto seconds = std::chrono::duration_cast<Clock::duration>(FSec(GetArg(1).GetValue()));
-
       if (m_state)
       {
-        m_release_time += seconds;
+        if (accumulate)
+          m_release_time += seconds;
+        else
+          m_release_time = seconds;
       }
       else
       {
         m_state = true;
-        m_release_time = now + seconds;
+        m_release_time = seconds;
       }
     }
 
-    if (m_state && now >= m_release_time)
+    if (m_state && m_release_time <= 0.0)
     {
       m_state = false;
     }
+    m_release_time =
+        std::max(0.0, m_release_time - ControllerInterface::GetCurrentInputDeltaSeconds());
 
     return m_state;
   }
 
-private:
   mutable bool m_released = false;
   mutable bool m_state = false;
-  mutable Clock::time_point m_release_time = Clock::now();
+  mutable double m_release_time = 0.0;
 };
 
+// usage: ignoreFocus(expression)
+class IgnoreFocusExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Forces the focus requirements of the expression to be ignored");
+  }
+
+  // No need to keep the inner expression flags as they'd be ignored anyway
+  Device::FocusFlags GetFocusFlags() const override { return Device::FocusFlags::IgnoreFocus; }
+
+  ControlState GetValue() const override { return GetArg(0).GetValue(); }
+};
+
+// usage: ignoreOnFocusChange(expression)
+class IgnoreOnFocusChangeExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Forces the expression to be ignored until on focus acquired");
+  }
+
+  Device::FocusFlags GetFocusFlags() const override
+  {
+    // Add the required flag, keep the previous ones, as long as they don't conflict
+    u8 focus_flags = u8(FunctionExpression::GetFocusFlags());
+    focus_flags &= ~u8(Device::FocusFlags::IgnoreFocus);
+    return Device::FocusFlags(focus_flags | u8(Device::FocusFlags::IgnoreOnFocusChanged));
+  }
+
+  ControlState GetValue() const override { return GetArg(0).GetValue(); }
+};
+
+// usage: requireFocus(expression)
+// This already enforces check for Full Focus, we shouldn't need one for Focus only.
+class RequireFocusExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"expression"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Forces focus to be checked on the expression. This is mostly needed for "
+                  "outputs which ignore focus by default");
+  }
+
+  Device::FocusFlags GetFocusFlags() const override
+  {
+    // Add the required flag, keep the previous ones, as long as they don't conflict
+    u8 focus_flags = u8(FunctionExpression::GetFocusFlags());
+    focus_flags &= ~u8(Device::FocusFlags::IgnoreFocus);
+    return Device::FocusFlags(focus_flags | u8(Device::FocusFlags::RequireFullFocus));
+  }
+
+  ControlState GetValue() const override { return GetArg(0).GetValue(); }
+};
+
+// usage: (return value)gameSpeed()
+// We don't want this to be used as control so we don't return 1 to CountNumControls()
+class GameSpeedExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 0)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"none"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Returns the game speed from the last frame (1 is full speed). Can be used "
+                  "similarly to a time delta");
+  }
+
+  ControlState GetValue() const override
+  {
+    if ((ControllerInterface::GetCurrentInputChannel() != InputChannel::SerialInterface &&
+         ControllerInterface::GetCurrentInputChannel() != InputChannel::Bluetooth) ||
+        ::Core::GetState() == ::Core::State::Uninitialized)
+      return 1;
+    return ::Core::GetActualEmulationSpeed();
+  }
+};
+
+// usage: timeToInputFrames(seconds)
+class TimeToInputFramesExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"seconds"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("If you don't want to deal with input update calculations you can use "
+                  "this function to convert seconds to input frames. You can't preview "
+                  "values when the emulation is not running");
+  }
+
+  ControlState GetValue() const override
+  {
+    return GetArg(0).GetValue() / ControllerInterface::GetTargetInputDeltaSeconds();
+  }
+};
+
+// usage: videoToInputFrames(frames)
+class VideoToInputFramesExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 1)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"frames"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans(
+        "Input isn't updated with the same frequency as the video, so some functions ask "
+        "for a duration in input frames. Use this to convert to it as not all input frames are "
+        "guaranteed to be read by the game. The actual game frame rate won't influence this, only "
+        "the video refresh rate will. You can't preview values when the emulation is not running."
+        " Ignored for non game mappings");
+  }
+
+  ControlState GetValue() const override
+  {
+    if ((ControllerInterface::GetCurrentInputChannel() != InputChannel::SerialInterface &&
+         ControllerInterface::GetCurrentInputChannel() != InputChannel::Bluetooth) ||
+        ::Core::GetState() == ::Core::State::Uninitialized)
+      return GetArg(0).GetValue();
+    return GetArg(0).GetValue() * (ControllerInterface::GetTargetInputDeltaSeconds() *
+                                   VideoInterface::GetTargetRefreshRate());
+  }
+};
+
+// usage: (return value)hasFocus()
+// We don't want this to be used as control so we don't return 1 to CountNumControls()
+class HasFocusExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 0)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"none"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    return _trans("Can be used to cache inputs values on focus loss, or to trigger inputs the "
+                  "window loses focus, like pausing the game pause or changing the emulation speed."
+                  " Only applies to the emulation window");
+  }
+
+  Device::FocusFlags GetFocusFlags() const override { return Device::FocusFlags::IgnoreFocus; }
+
+  ControlState GetValue() const override
+  {
+    // Ignore this for non game channels, it's not necessary (also couldn't be tested in the UI)
+    if (ControllerInterface::GetCurrentInputChannel() != InputChannel::SerialInterface &&
+        ControllerInterface::GetCurrentInputChannel() != InputChannel::Bluetooth)
+      return true;
+    // There is no need to cache this, nor to return the control gate cached version of focus,
+    // we want this to be as up to date as possible
+    return Host_RendererHasFocus();
+  }
+};
+
+// usage: scaleSet(output, scale)
+class ScaleSetExpression : public FunctionExpression
+{
+private:
+  ArgumentValidation
+  ValidateArguments(const std::vector<std::unique_ptr<Expression>>& args) override
+  {
+    if (args.size() == 2)
+      return ArgumentsAreValid{};
+    else
+      return ExpectedArguments{"output, scale"};
+  }
+
+  const char* GetDescription(bool for_input) const override
+  {
+    if (for_input)
+      return nullptr;
+    return _trans("Scales an output value");
+  }
+
+  void SetValue(ControlState value) override { GetArg(0).SetValue(value * GetArg(1).GetValue()); }
+
+  // Just return a multiplication if this was accidentally used on inputs
+  ControlState GetValue() const override { return GetArg(0).GetValue() * GetArg(1).GetValue(); }
+};
+
+// Where there are two names it's to maintain compatibility with previous names
 std::unique_ptr<FunctionExpression> MakeFunctionExpression(std::string_view name)
 {
-  if (name == "not")
-    return std::make_unique<NotExpression>();
+  // Logic/Math:
   if (name == "if")
     return std::make_unique<IfExpression>();
+  if (name == "not")
+    return std::make_unique<NotExpression>();
+  if (name == "min")
+    return std::make_unique<MinExpression>();
+  if (name == "max")
+    return std::make_unique<MaxExpression>();
+  if (name == "clamp")
+    return std::make_unique<ClampExpression>();
+  if (name == "minus")
+    return std::make_unique<UnaryMinusExpression>();
+  if (name == "pow")
+    return std::make_unique<PowExpression>();
+  if (name == "sqrt")
+    return std::make_unique<SqrtExpression>();
   if (name == "sin")
     return std::make_unique<SinExpression>();
   if (name == "cos")
@@ -655,34 +1628,72 @@ std::unique_ptr<FunctionExpression> MakeFunctionExpression(std::string_view name
     return std::make_unique<ATanExpression>();
   if (name == "atan2")
     return std::make_unique<ATan2Expression>();
-  if (name == "sqrt")
-    return std::make_unique<SqrtExpression>();
-  if (name == "pow")
-    return std::make_unique<PowExpression>();
-  if (name == "min")
-    return std::make_unique<MinExpression>();
-  if (name == "max")
-    return std::make_unique<MaxExpression>();
-  if (name == "clamp")
-    return std::make_unique<ClampExpression>();
-  if (name == "timer")
-    return std::make_unique<TimerExpression>();
+  // State/time based:
+  if (name == "onPress")
+    return std::make_unique<OnPressExpression>();
+  if (name == "onRelease")
+    return std::make_unique<OnReleaseExpression>();
+  if (name == "onChange")
+    return std::make_unique<OnChangeExpression>();
+  if (name == "cache")  // Output as well
+    return std::make_unique<CacheExpression>();
+  if (name == "onHold" || name == "hold")
+    return std::make_unique<OnHoldExpression>();
   if (name == "toggle")
     return std::make_unique<ToggleExpression>();
-  if (name == "minus")
-    return std::make_unique<UnaryMinusExpression>();
-  if (name == "deadzone")
-    return std::make_unique<DeadzoneExpression>();
-  if (name == "smooth")
+  if (name == "onTap" || name == "tap")
+    return std::make_unique<OnTapExpression>();
+  // It would be nice to remove the old name "relative" from here but we'd break existing functions
+  if (name == "sharedRelative" || name == "relative")
+    return std::make_unique<SharedRelativeExpression>();
+  if (name == "relativeToSpeed")
+    return std::make_unique<RelativeToSpeedExpression>();
+  if (name == "smooth" || name == "toRelative")
     return std::make_unique<SmoothExpression>();
-  if (name == "hold")
-    return std::make_unique<HoldExpression>();
-  if (name == "tap")
-    return std::make_unique<TapExpression>();
-  if (name == "relative")
-    return std::make_unique<RelativeExpression>();
   if (name == "pulse")
     return std::make_unique<PulseExpression>();
+  if (name == "timer")
+    return std::make_unique<TimerExpression>();
+  if (name == "interval")
+    return std::make_unique<IntervalExpression>();
+  // Recordings:
+  if (name == "average")
+    return std::make_unique<AverageExpression>();
+  if (name == "sum")
+    return std::make_unique<SumExpression>();
+  if (name == "record")
+    return std::make_unique<RecordExpression>();
+  if (name == "sequence")
+    return std::make_unique<SequenceExpression>();
+  if (name == "lag")
+    return std::make_unique<LagExpression>();
+  // Stick helpers:
+  if (name == "deadzone")
+    return std::make_unique<DeadzoneExpression>();
+  if (name == "antiDeadzone")
+    return std::make_unique<AntiDeadzoneExpression>();
+  if (name == "bezierCurve")
+    return std::make_unique<BezierCurveExpression>();
+  if (name == "antiAcceleration")
+    return std::make_unique<AntiAccelerationExpression>();
+  // Meta/Focus:
+  if (name == "gameSpeed")
+    return std::make_unique<GameSpeedExpression>();
+  if (name == "timeToInputFrames")
+    return std::make_unique<TimeToInputFramesExpression>();
+  if (name == "videoToInputFrames")
+    return std::make_unique<VideoToInputFramesExpression>();
+  if (name == "hasFocus")
+    return std::make_unique<HasFocusExpression>();
+  if (name == "ignoreFocus")
+    return std::make_unique<IgnoreFocusExpression>();
+  if (name == "ignoreOnFocusChange")
+    return std::make_unique<IgnoreOnFocusChangeExpression>();
+  if (name == "requireFocus")
+    return std::make_unique<RequireFocusExpression>();
+  // Setter/Output:
+  if (name == "scaleSet")
+    return std::make_unique<ScaleSetExpression>();
 
   return nullptr;
 }
@@ -697,10 +1708,21 @@ int FunctionExpression::CountNumControls() const
   return result;
 }
 
-void FunctionExpression::UpdateReferences(ControlEnvironment& env)
+Device::FocusFlags FunctionExpression::GetFocusFlags() const
+{
+  u8 focus_flags = 0;
+  if (m_args.size() == 0)
+    focus_flags = u8(Device::FocusFlags::Default);
+  // By default functions sum up all the focus requirements of their args
+  for (u32 i = 0; i < u32(m_args.size()); ++i)
+    focus_flags |= u8(GetArg(i).GetFocusFlags());
+  return Device::FocusFlags(focus_flags);
+}
+
+void FunctionExpression::UpdateReferences(ControlEnvironment& env, bool is_input)
 {
   for (auto& arg : m_args)
-    arg->UpdateReferences(env);
+    arg->UpdateReferences(env, is_input);
 }
 
 FunctionExpression::ArgumentValidation
@@ -726,8 +1748,13 @@ u32 FunctionExpression::GetArgCount() const
   return u32(m_args.size());
 }
 
-void FunctionExpression::SetValue(ControlState)
+void FunctionExpression::SetValue(ControlState value)
 {
+  // By default just pass along all the values and ignore the function as
+  // the expression will build fine even if it's an output reference
+  for (auto& arg : m_args)
+  {
+    arg->SetValue(value);
+  }
 }
-
 }  // namespace ciface::ExpressionParser

--- a/Source/Core/InputCommon/ControlReference/FunctionExpression.h
+++ b/Source/Core/InputCommon/ControlReference/FunctionExpression.h
@@ -14,8 +14,13 @@
 
 namespace ciface::ExpressionParser
 {
+// if input > this, then it passes
 constexpr ControlState CONDITION_THRESHOLD = 0.5;
 
+// [arg] means that it's optional and can be not inserted.
+// arg = x means that it will default to that value if you don't specify it.
+// ... means that unlimited args are supported.
+// Make sure to call GetValue() on every arg within your GetValue()
 class FunctionExpression : public Expression
 {
 public:
@@ -31,9 +36,13 @@ public:
   using ArgumentValidation = std::variant<ArgumentsAreValid, ExpectedArguments>;
 
   int CountNumControls() const override;
-  void UpdateReferences(ControlEnvironment& env) override;
+  Device::FocusFlags GetFocusFlags() const override;
+  void UpdateReferences(ControlEnvironment& env, bool is_input) override;
 
   ArgumentValidation SetArguments(std::vector<std::unique_ptr<Expression>>&& args);
+
+  // These will be shown in the UI so wrap them in _trans(). Automatically word wrapped.
+  virtual const char* GetDescription(bool for_input) const { return nullptr; };
 
   void SetValue(ControlState value) override;
 

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.cpp
@@ -9,13 +9,15 @@
 
 namespace ControllerEmu
 {
-Input::Input(Translatability translate_, std::string name_, std::string ui_name_)
-    : Control(std::make_unique<InputReference>(), translate_, std::move(name_), std::move(ui_name_))
+Input::Input(Translatability translate_, std::string name_, std::string ui_name_,
+             ControlState range)
+    : Control(std::make_unique<InputReference>(range), translate_, std::move(name_),
+              std::move(ui_name_))
 {
 }
 
-Input::Input(Translatability translate_, std::string name_)
-    : Control(std::make_unique<InputReference>(), translate_, std::move(name_))
+Input::Input(Translatability translate_, std::string name_, ControlState range)
+    : Control(std::make_unique<InputReference>(range), translate_, std::move(name_))
 {
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Input.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Input.h
@@ -11,7 +11,9 @@ namespace ControllerEmu
 class Input : public Control
 {
 public:
-  Input(Translatability translate, std::string name, std::string ui_name);
-  Input(Translatability translate, std::string name);
+  Input(Translatability translate, std::string name, std::string ui_name,
+        ControlState range = ControlReference::DEFAULT_RANGE);
+  Input(Translatability translate, std::string name,
+        ControlState range = ControlReference::DEFAULT_RANGE);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Output.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Output.cpp
@@ -9,8 +9,8 @@
 
 namespace ControllerEmu
 {
-Output::Output(Translatability translate_, std::string name_)
-    : Control(std::make_unique<OutputReference>(), translate_, std::move(name_))
+Output::Output(Translatability translate_, std::string name_, ControlState range)
+    : Control(std::make_unique<OutputReference>(range), translate_, std::move(name_))
 {
 }
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/Control/Output.h
+++ b/Source/Core/InputCommon/ControllerEmu/Control/Output.h
@@ -11,6 +11,7 @@ namespace ControllerEmu
 class Output : public Control
 {
 public:
-  Output(Translatability translate, std::string name);
+  Output(Translatability translate, std::string name,
+         ControlState range = ControlReference::DEFAULT_RANGE);
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/AnalogStick.cpp
@@ -28,7 +28,7 @@ AnalogStick::AnalogStick(const char* const name_, const char* const ui_name_,
   for (auto& named_direction : named_directions)
     AddInput(Translate, named_direction);
 
-  AddInput(Translate, _trans("Modifier"));
+  AddInput(Translate, _trans("Modifier"), 0.5);
 }
 
 AnalogStick::ReshapeData AnalogStick::GetReshapableState(bool adjusted) const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Attachments.cpp
@@ -27,6 +27,7 @@ u32 Attachments::GetSelectedAttachment() const
 
 void Attachments::SetSelectedAttachment(u32 val)
 {
+  const auto lock = EmulatedController::GetStateLock();
   m_selection_setting.SetValue(val);
 }
 

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -68,17 +68,21 @@ public:
 
   void SetControlExpression(int index, const std::string& expression);
 
-  void AddInput(Translatability translate, std::string name);
-  void AddInput(Translatability translate, std::string name, std::string ui_name);
-  void AddOutput(Translatability translate, std::string name);
+  void AddInput(Translatability translate, std::string name,
+                ControlState range = ControlReference::DEFAULT_RANGE);
+  void AddInput(Translatability translate, std::string name, std::string ui_name,
+                ControlState range = ControlReference::DEFAULT_RANGE);
+  void AddOutput(Translatability translate, std::string name,
+                 ControlState range = ControlReference::DEFAULT_RANGE);
 
   template <typename T>
   void AddSetting(SettingValue<T>* value, const NumericSettingDetails& details,
                   std::common_type_t<T> default_value_, std::common_type_t<T> min_value = {},
-                  std::common_type_t<T> max_value = T(100))
+                  std::common_type_t<T> max_value = T(100),
+                  const NumericSetting<bool>* edit_condition = nullptr)
   {
-    numeric_settings.emplace_back(
-        std::make_unique<NumericSetting<T>>(value, details, default_value_, min_value, max_value));
+    numeric_settings.emplace_back(std::make_unique<NumericSetting<T>>(
+        value, details, default_value_, min_value, max_value, edit_condition));
   }
 
   void AddVirtualNotchSetting(SettingValue<double>* value, double max_virtual_notch_deg);
@@ -98,6 +102,8 @@ public:
 
   bool enabled = true;
   std::vector<std::unique_ptr<Control>> controls;
+  // Settings can point to each other so never remove them individually.
+  // There might be settings that are not in this list.
   std::vector<std::unique_ptr<NumericSettingBase>> numeric_settings;
 };
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Cursor.cpp
@@ -7,22 +7,24 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <ratio>
 #include <string>
 
 #include "Common/Common.h"
 #include "Common/MathUtil.h"
+#include "Core/Core.h"
 
-#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
-#include "InputCommon/ControllerEmu/Control/Input.h"
 #include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
+#include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 namespace ControllerEmu
 {
+using milli_with_remainder = std::chrono::duration<double, std::milli>;
+
 Cursor::Cursor(std::string name_, std::string ui_name_)
-    : ReshapableInput(std::move(name_), std::move(ui_name_), GroupType::Cursor),
-      m_last_update(Clock::now())
+    : ReshapableInput(std::move(name_), std::move(ui_name_), GroupType::Cursor)
 {
   for (auto& named_direction : named_directions)
     AddInput(Translate, named_direction);
@@ -68,11 +70,13 @@ Cursor::ReshapeData Cursor::GetReshapableState(bool adjusted) const
   const ControlState y = controls[0]->GetState() - controls[1]->GetState();
   const ControlState x = controls[3]->GetState() - controls[2]->GetState();
 
-  // Return raw values. (used in UI)
+  // Return raw values
   if (!adjusted)
     return {x, y};
 
-  return Reshape(x, y, 0.0);
+  // Values are clamped later on, the maximum movement between two frames
+  // should not be clamped in relative mode
+  return Reshape(x, y, 0.0, std::numeric_limits<ControlState>::infinity());
 }
 
 ControlState Cursor::GetGateRadiusAtAngle(double ang) const
@@ -80,74 +84,88 @@ ControlState Cursor::GetGateRadiusAtAngle(double ang) const
   return SquareStickGate(1.0).GetRadiusAtAngle(ang);
 }
 
-Cursor::StateData Cursor::GetState(const bool adjusted)
+// TODO: pass in the state as reference and let wiimote and UI keep their own state.
+Cursor::StateData Cursor::GetState(bool is_ui, float time_elapsed)
 {
-  if (!adjusted)
-  {
-    const auto raw_input = GetReshapableState(false);
-
-    return {raw_input.x, raw_input.y};
-  }
+  const int i = is_ui ? 1 : 0;
 
   const auto input = GetReshapableState(true);
 
-  // TODO: Using system time is ugly.
-  // Kill this after state is moved into wiimote rather than this class.
-  const auto now = Clock::now();
-  const auto ms_since_update =
-      std::chrono::duration_cast<std::chrono::milliseconds>(now - m_last_update).count();
-  m_last_update = now;
-
-  const double max_step = STEP_PER_SEC / 1000.0 * ms_since_update;
-
-  // Relative input:
-  if (m_relative_setting.GetValue() ^ (controls[6]->GetState<bool>()))
+  // Relative input (the second check is for Hold):
+  if (m_relative_setting.GetValue() ^ controls[6]->GetState<bool>())
   {
     // Recenter:
     if (controls[5]->GetState<bool>())
     {
-      m_state.x = 0.0;
-      m_state.y = 0.0;
+      m_state[i].x = 0.0;
+      m_state[i].y = 0.0;
     }
     else
     {
-      m_state.x = std::clamp(m_state.x + input.x * max_step, -1.0, 1.0);
-      m_state.y = std::clamp(m_state.y + input.y * max_step, -1.0, 1.0);
+      // Here we have two choices: to divide by the emulation speed or not.
+      // The first one would be good if the relative input is mapped to buttons
+      // or an analog stick, the second one would be good for a mouse or touch pad.
+      // In general, this is more likely to be mapped to a mouse, but if not, users
+      // can always use input expressions to pre-divide their input by the emu speed.
+      const double step = STEP_PER_SEC * time_elapsed;
+
+      m_state[i].x += input.x * step;
+      m_state[i].y += input.y * step;
     }
   }
   // Absolute input:
   else
   {
-    m_state.x = input.x;
-    m_state.y = input.y;
+    m_state[i].x = input.x;
+    m_state[i].y = input.y;
   }
 
-  StateData result = m_state;
+  // Clamp between -1 and 1, before auto hide. Clamping after auto hide could make it easier to find
+  // when you've lost the cursor but it could also make it more annoying.
+  // If we don't do this, we could go over the user specified angles (which can just be increased
+  // instead), or lose the cursor over the borders.
+  m_state[i].x = std::clamp(m_state[i].x, -1.0, 1.0);
+  m_state[i].y = std::clamp(m_state[i].y, -1.0, 1.0);
+
+  StateData result = m_state[i];
 
   const bool autohide = m_autohide_setting.GetValue();
+  const bool has_moved = std::abs(m_prev_state[i].x - result.x) > AUTO_HIDE_DEADZONE ||
+                         std::abs(m_prev_state[i].y - result.y) > AUTO_HIDE_DEADZONE;
 
-  // Auto-hide timer:
-  // TODO: should Z movement reset this?
-  if (!autohide || std::abs(m_prev_result.x - result.x) > AUTO_HIDE_DEADZONE ||
-      std::abs(m_prev_result.y - result.y) > AUTO_HIDE_DEADZONE)
+  // Auto-hide timer (ignores Z):
+  if (!autohide || has_moved)
   {
-    m_auto_hide_timer = AUTO_HIDE_MS;
+    m_auto_hide_timer[i] = AUTO_HIDE_MS;
   }
-  else if (m_auto_hide_timer)
+  if (autohide && !has_moved && m_auto_hide_timer[i] > 0)
   {
-    m_auto_hide_timer -= std::min<int>(ms_since_update, m_auto_hide_timer);
+    // Auto should be based on real world time, independent of emulation speed
+    const float emulation_speed = is_ui ? 1.f : static_cast<float>(Core::GetActualEmulationSpeed());
+    m_auto_hide_timer[i] -= static_cast<int>((time_elapsed * 1000.f) / emulation_speed);
+    m_auto_hide_timer[i] = std::max(m_auto_hide_timer[i], 0);
   }
 
-  m_prev_result = result;
+  m_prev_state[i] = result;
 
   // If auto-hide time is up or hide button is held:
-  if (!m_auto_hide_timer || controls[4]->GetState<bool>())
+  if (m_auto_hide_timer[i] <= 0 || controls[4]->GetState<bool>())
   {
     result.x = std::numeric_limits<ControlState>::quiet_NaN();
     result.y = 0;
   }
 
   return result;
+}
+
+void Cursor::ResetState(bool is_ui)
+{
+  const int i = is_ui ? 1 : 0;
+
+  m_state[i] = {};
+  m_prev_state[i] = {};
+
+  m_auto_hide_timer[i] = AUTO_HIDE_MS;
 }
 
 ControlState Cursor::GetTotalYaw() const

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUAccelerometer.cpp
@@ -7,8 +7,10 @@
 #include <memory>
 
 #include "Common/Common.h"
-#include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Control/Input.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
 
 namespace ControllerEmu
 {

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.cpp
@@ -11,6 +11,8 @@
 
 #include "InputCommon/ControlReference/ControlReference.h"
 #include "InputCommon/ControllerEmu/Control/Control.h"
+#include "InputCommon/ControllerEmu/Control/Input.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
 
 namespace ControllerEmu
 {
@@ -129,8 +131,10 @@ bool IMUGyroscope::AreInputsBound() const
 
 bool IMUGyroscope::CanCalibrate() const
 {
-  // If the input gate is disabled, miscalibration to zero values would occur.
-  return ControlReference::GetInputGate();
+  // Return true if all controls current pass the control gate (so their values would be correct),
+  // otherwise miscalibration to zero values could occur.
+  return std::all_of(controls.begin(), controls.end(),
+                     [](const auto& control) { return control->control_ref->PassesGate(); });
 }
 
 std::optional<IMUGyroscope::StateData> IMUGyroscope::GetState(bool update)

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/IMUGyroscope.h
@@ -22,8 +22,8 @@ public:
   IMUGyroscope(std::string name, std::string ui_name);
 
   StateData GetRawState() const;
-  // Also updates the state by default
-  std::optional<StateData> GetState(bool update = true);
+  // Also updates the state
+  std::optional<StateData> GetState(bool update = false);
 
   // Value is in rad/s.
   ControlState GetDeadzone() const;

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/Tilt.cpp
@@ -22,7 +22,7 @@ Tilt::Tilt(const std::string& name_) : ReshapableInput(name_, name_, GroupType::
   AddInput(Translate, _trans("Left"));
   AddInput(Translate, _trans("Right"));
 
-  AddInput(Translate, _trans("Modifier"));
+  AddInput(Translate, _trans("Modifier"), 0.5);
 
   AddSetting(&m_max_angle_setting,
              {_trans("Angle"),

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.cpp
@@ -27,27 +27,27 @@ const char* NumericSettingBase::GetUIDescription() const
 }
 
 template <>
-void NumericSetting<int>::SetExpressionFromValue()
+std::string NumericSetting<int>::GetExpressionFromValue() const
 {
-  m_value.m_input.SetExpression(ValueToString(GetValue()));
+  return ValueToString(int(GetValue()));
 }
 
 template <>
-void NumericSetting<double>::SetExpressionFromValue()
+std::string NumericSetting<double>::GetExpressionFromValue() const
 {
   // We must use a dot decimal separator for expression parser.
   std::ostringstream ss;
   ss.imbue(std::locale::classic());
   ss << GetValue();
 
-  m_value.m_input.SetExpression(ss.str());
+  return ss.str();
 }
 
 template <>
-void NumericSetting<bool>::SetExpressionFromValue()
+std::string NumericSetting<bool>::GetExpressionFromValue() const
 {
   // Cast bool to prevent "true"/"false" strings.
-  m_value.m_input.SetExpression(ValueToString(int(GetValue())));
+  return ValueToString(int(GetValue()));
 }
 
 template <>

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -6,9 +6,11 @@
 #include <atomic>
 #include <string>
 
+#include "Common/Assert.h"
 #include "Common/CommonTypes.h"
 #include "Common/IniFile.h"
 #include "InputCommon/ControlReference/ControlReference.h"
+#include "InputCommon/ControllerEmu/ControllerEmu.h"
 #include "InputCommon/ControllerInterface/CoreDevice.h"
 
 namespace ControllerEmu
@@ -56,12 +58,24 @@ public:
   virtual InputReference& GetInputReference() = 0;
   virtual const InputReference& GetInputReference() const = 0;
 
+  // Can be edited in UI? This setting should not used if is false
+  virtual bool IsEnabled() const = 0;
+  virtual bool HasEditCondition() const = 0;
+
+  virtual ControlState GetGenericValue() const = 0;
+
+  virtual ControlState GetGenericMinValue() const = 0;
+  virtual ControlState GetGenericMaxValue() const = 0;
+
   virtual bool IsSimpleValue() const = 0;
 
   // Convert a literal expression e.g. "7.0" to a regular value. (disables expression parsing)
   virtual void SimplifyIfPossible() = 0;
 
+  virtual void Update() = 0;
+
   // Convert a regular value to an expression. (used before expression editing)
+  virtual std::string GetExpressionFromValue() const = 0;
   virtual void SetExpressionFromValue() = 0;
 
   virtual SettingType GetType() const = 0;
@@ -77,6 +91,7 @@ protected:
 template <typename T>
 class SettingValue;
 
+// Needs EmulatedController::GetStateLock() on anything that mutates it (not GetValue())
 template <typename T>
 class NumericSetting final : public NumericSettingBase
 {
@@ -88,15 +103,21 @@ public:
                 "NumericSetting is only implemented for int, double, and bool.");
 
   NumericSetting(SettingValue<ValueType>* value, const NumericSettingDetails& details,
-                 ValueType default_value, ValueType min_value, ValueType max_value)
+                 ValueType default_value, ValueType min_value, ValueType max_value,
+                 const NumericSetting<bool>* edit_condition = nullptr)
       : NumericSettingBase(details), m_value(*value), m_default_value(default_value),
-        m_min_value(min_value), m_max_value(max_value)
+        m_min_value(min_value), m_max_value(max_value), m_edit_condition(edit_condition)
   {
+    ASSERT(m_max_value >= m_min_value);  // Let them be equal
+    // Theoretically not needed but avoids log errors
+    const auto lock = EmulatedController::GetStateLock();
     m_value.SetValue(m_default_value);
   }
 
   void LoadFromIni(const IniFile::Section& section, const std::string& group_name) override
   {
+    // Note that even if we have a range value, we completely ignore it because it would
+    // be useless and it's not exposed to the user
     std::string str_value;
     if (section.Get(group_name + m_details.ini_name, &str_value))
     {
@@ -124,25 +145,82 @@ public:
     }
   }
 
+  // If the edit condition isn't simplified, its value might change at runtime, but this
+  // is for UI only so it's fine.
+  bool IsEnabled() const override { return !m_edit_condition || m_edit_condition->GetValue(); }
+  bool HasEditCondition() const override { return m_edit_condition != nullptr; }
+
   bool IsSimpleValue() const override { return m_value.IsSimpleValue(); }
 
+  // Simplification has its limit, but is also not really necessary,
+  // so if we have an expression with only fixed values, like 2+3, it won't be simplified.
+  // Only call this if the expression has changed or you will lose your value.
   void SimplifyIfPossible() override
   {
+    if (IsSimpleValue())  // Expression is empty, simplify to 0
+    {
+      m_value.SetValue(ValueType());
+      return;
+    }
+
+    // TODO: Theoretically we should ask the expression if its value is fixed or not, and if it is,
+    // just copy its value into ours, with something similar to ControlReference::BoundCount().
+    // Otherwise if we have an expression like "(7*9/3)" it won't be simplified.
+
+    // Strip spaces and line breaks around the edges because the expression keeps them.
+    const std::string stripped_expression(StripSpaces(m_value.m_input.GetExpression()));
     ValueType value;
-    if (TryParse(m_value.m_input.GetExpression(), &value))
+    bool value_found = false;
+    if constexpr (std::is_same<ValueType, bool>())
+    {
+      ControlState temp_value = ControlState(GetValue());
+      // Any expression that isn't exactly 0 or 1 would fail to parse to bool
+      if (TryParse(stripped_expression, &temp_value))
+      {
+        value = std::lround(temp_value) > 0;
+        value_found = true;
+      }
+      // Fallback to bool parsing if number parsing failed, this will also work with "true/false"
+      else if (TryParse(stripped_expression, &value))
+      {
+        value_found = true;
+      }
+    }
+    else if (TryParse(stripped_expression, &value))
+    {
+      value_found = true;
+    }
+    // Only simplify if within the accepted ranges, to not force users to write numbers around "()".
+    // It's a shame to not have it simplified but otherwise we'd need to rewrite a lot of UI code to
+    // unlock the ranges over the allowed min/max, to avoid the UI resetting the values.
+    if (value_found && value >= GetMinValue() && value <= GetMaxValue())
       m_value.SetValue(value);
   }
 
-  void SetExpressionFromValue() override;
+  void Update() override
+  {
+    if (!IsSimpleValue())  // Only update the expression if it's not been simplified
+      m_value.m_input.UpdateState();
+  }
+
+  std::string GetExpressionFromValue() const override;
+  void SetExpressionFromValue() override
+  {
+    m_value.m_input.SetExpression(std::move(GetExpressionFromValue()));
+  }
   InputReference& GetInputReference() override { return m_value.m_input; }
   const InputReference& GetInputReference() const override { return m_value.m_input; }
 
+  ControlState GetGenericValue() const override { return ControlState(GetValue()); }
   ValueType GetValue() const { return m_value.GetValue(); }
   void SetValue(ValueType value) { m_value.SetValue(value); }
 
   ValueType GetDefaultValue() const { return m_default_value; }
+  // These are only for UI and they are not applied if IsSimpleValue() is false
   ValueType GetMinValue() const { return m_min_value; }
   ValueType GetMaxValue() const { return m_max_value; }
+  ControlState GetGenericMinValue() const override { return ControlState(GetMinValue()); }
+  ControlState GetGenericMaxValue() const override { return ControlState(GetMaxValue()); }
 
   SettingType GetType() const override;
 
@@ -152,8 +230,12 @@ private:
   const ValueType m_default_value;
   const ValueType m_min_value;
   const ValueType m_max_value;
+
+  // Assuming settings are never destroyed if not all together
+  const NumericSetting<bool>* const m_edit_condition;
 };
 
+// Needs EmulatedController::GetStateLock() on SetValue()
 template <typename T>
 class SettingValue
 {
@@ -164,31 +246,33 @@ class SettingValue
 public:
   ValueType GetValue() const
   {
-    // Only update dynamic values when the input gate is enabled.
-    // Otherwise settings will all change to 0 when window focus is lost.
-    // This is very undesirable for things like battery level or attached extension.
-    if (!IsSimpleValue() && ControlReference::GetInputGate())
-      m_value = m_input.GetState<ValueType>();
-
+    // IsSimpleValue() could theoretically change while we are within this call but
+    // at worse it will return the previous m_value for one frame
+    if (!IsSimpleValue())
+      return m_input.GetState<ValueType>();
     return m_value;
   }
 
-  bool IsSimpleValue() const { return m_input.GetExpression().empty(); }
+  bool IsSimpleValue() const
+  {
+    // An empty or all spaces expression string won't set parsing as succeeded.
+    // An invalid expression will return 0 so we could just simplify it anyway, but then
+    // if we wanted to go back to its widget to fix the expression the expression would be lost.
+    return m_input.GetParseStatus() == ciface::ExpressionParser::ParseStatus::EmptyExpression;
+  }
 
 private:
   void SetValue(ValueType value)
   {
     m_value = value;
-
     // Clear the expression to use our new "simple" value.
     m_input.SetExpression("");
   }
 
-  // Values are R/W by both UI and CPU threads.
-  mutable std::atomic<ValueType> m_value = {};
+  // This won't be reset if we aren't simple anymore, just ignore it
+  std::atomic<ValueType> m_value = {};
 
-  // Unfortunately InputReference's state grabbing is non-const requiring mutable here.
-  mutable InputReference m_input;
+  IgnoreGateInputReference m_input;
 };
 
 }  // namespace ControllerEmu

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -313,11 +313,7 @@ ReshapableInput::ReshapeData ReshapableInput::Reshape(ControlState x, ControlSta
   // This is affected by the modifier's "range" setting which defaults to 50%.
   if (modifier)
   {
-    // TODO: Modifier's range setting gets reset to 100% when the clear button is clicked.
-    // This causes the modifier to not behave how a user might suspect.
-    // Retaining the old scale-by-50% behavior until range is fixed to clear to 50%.
-    dist *= 0.5;
-    // dist *= modifier;
+    dist *= modifier;
   }
 
   // Apply deadzone as a percentage of the user-defined calibration shape/size:

--- a/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ControllerInterface.cpp
@@ -4,6 +4,7 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 
 #include <algorithm>
+#include <chrono>
 
 #include "Common/Assert.h"
 #include "Common/Logging/Log.h"
@@ -37,16 +38,26 @@
 
 ControllerInterface g_controller_interface;
 
+using Clock = std::chrono::steady_clock;
+
 // We need to save which input channel we are in by thread, so we can access the correct input
 // update values in different threads by input channel. We start from InputChannel::Host on all
 // threads as hotkeys are updated from a worker thread, but UI can read from the main thread. This
 // will never interfere with game threads.
 static thread_local ciface::InputChannel tls_input_channel = ciface::InputChannel::Host;
+static double s_input_channels_delta_seconds[u8(ciface::InputChannel::Max)];
+static double s_input_channels_target_delta_seconds[u8(ciface::InputChannel::Max)];
+static s32 s_input_channels_updates_per_target[u8(ciface::InputChannel::Max)];
+static double s_input_channels_real_delta_seconds[u8(ciface::InputChannel::Max)];
+static Clock::time_point s_input_channels_last_update[u8(ciface::InputChannel::Max)];
 
 void ControllerInterface::Initialize(const WindowSystemInfo& wsi)
 {
   if (m_is_init)
     return;
+
+  for (u8 i = 0; i < u8(ciface::InputChannel::Max); ++i)
+    s_input_channels_last_update[i] = Clock::now();
 
   std::lock_guard lk_population(m_devices_population_mutex);
 
@@ -170,6 +181,8 @@ void ControllerInterface::RefreshDevices(RefreshReason reason)
   // with their own PlatformPopulateDevices().
   // This means that devices might end up in different order, unless we override their priority.
   // It also means they might appear as "disconnected" in the Qt UI for a tiny bit of time.
+  // There is an extremely low chance of no devices being added before emulated controllers load
+  // their default settings, but at worse that would cause a controller to have no default device.
 
 #ifdef CIFACE_USE_WIN32
   ciface::Win32::PopulateDevices(m_wsi.render_window);
@@ -287,12 +300,9 @@ void ControllerInterface::ClearDevices()
     if (m_devices.empty())
       return;
 
+    // Set outputs to ZERO before destroying device, just to be safe.
     for (const auto& d : m_devices)
-    {
-      // Set outputs to ZERO before destroying device
-      for (ciface::Core::Device::Output* o : d->Outputs())
-        o->SetState(0);
-    }
+      d->ResetOutput();
 
     // Devices will still be alive after this: there are shared ptrs around the code holding them,
     // but InvokeDevicesChangedCallbacks() will clean all of them.
@@ -337,6 +347,7 @@ bool ControllerInterface::AddDevice(std::shared_ptr<ciface::Core::Device> device
     }
 
     NOTICE_LOG_FMT(CONTROLLERINTERFACE, "Added device: {}", device->GetQualifiedName());
+
     m_devices.emplace_back(std::move(device));
 
     // We can't (and don't want) to control the order in which devices are added, but we
@@ -373,6 +384,7 @@ void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::De
     auto it = std::remove_if(m_devices.begin(), m_devices.end(), [&callback](const auto& dev) {
       if (callback(dev.get()))
       {
+        dev->ResetOutput();
         NOTICE_LOG_FMT(CONTROLLERINTERFACE, "Removed device: {}", dev->GetQualifiedName());
         return true;
       }
@@ -388,18 +400,45 @@ void ControllerInterface::RemoveDevice(std::function<bool(const ciface::Core::De
 }
 
 // Update input for all devices if lock can be acquired without waiting.
-void ControllerInterface::UpdateInput()
+void ControllerInterface::UpdateInput(ciface::InputChannel input_channel, double delta_seconds,
+                                      double target_delta_seconds, u32 updates_per_target)
 {
   // This should never happen
   ASSERT(m_is_init);
   if (!m_is_init)
     return;
 
+  // We set the read/write input channel here, see Device::RelativeInput for more info.
+  // The other information is used by FunctionExpression(s) to determine their timings.
+  // Inputs for this channel will be read immediately after this call.
+  // Make sure to not read them after the input channel has changed again (on the same thread).
+  tls_input_channel = input_channel;
+  u8 i = u8(tls_input_channel);
+  // This is not the actual world elapsed time, it's the emulation elapsed time
+  s_input_channels_delta_seconds[i] = delta_seconds;
+  // Delta seconds can be bigger or smaller than the target one, but they should average out
+  s_input_channels_target_delta_seconds[i] =
+      target_delta_seconds > 0.f ? target_delta_seconds : delta_seconds;
+  s_input_channels_updates_per_target[i] = updates_per_target;
+
+  // Calculate the real/world elapsed time.
+  // Useful to turn relative axes into "rate of change"/speed values usable by games
+  const auto now = Clock::now();
+  Clock::time_point& input_channel_last_update = s_input_channels_last_update[i];
+  s_input_channels_real_delta_seconds[i] =
+      std::chrono::duration_cast<std::chrono::duration<double>>(now - input_channel_last_update)
+          .count();
+  input_channel_last_update = now;
+
   // TODO: if we are an emulation input channel, we should probably always lock
   // Prefer outdated values over blocking UI or CPU thread (avoids short but noticeable frame drop)
   if (m_devices_mutex.try_lock())
   {
     std::lock_guard lk(m_devices_mutex, std::adopt_lock);
+
+    // Device::UpdateInput() would modify values read by ControlReference(s)
+    const auto lock = ControllerEmu::EmulatedController::GetDevicesInputLock();
+
     for (const auto& d : m_devices)
     {
       // Theoretically we could avoid updating input on devices that don't have any references to
@@ -409,14 +448,44 @@ void ControllerInterface::UpdateInput()
   }
 }
 
-void ControllerInterface::SetCurrentInputChannel(ciface::InputChannel input_channel)
+void ControllerInterface::SetInputChannel(ciface::InputChannel input_channel)
 {
   tls_input_channel = input_channel;
 }
 
-ciface::InputChannel ControllerInterface::GetCurrentInputChannel()
+// Call this when you are toggling pause or "closing" (stopping to update) an input channel.
+// Not mandatory.
+void ControllerInterface::SetChannelRunning(ciface::InputChannel input_channel, bool running)
 {
-  return tls_input_channel;
+  if (!m_is_init)
+    return;
+
+  std::lock_guard lk(m_devices_mutex);
+
+  const ciface::InputChannel prev_input_channel = tls_input_channel;
+  tls_input_channel = input_channel;
+
+  if (running)
+  {
+    // No need to clean s_input_channels_delta_seconds and the others
+    s_input_channels_last_update[u8(tls_input_channel)] = Clock::now();
+
+    const auto lock = ControllerEmu::EmulatedController::GetDevicesInputLock();
+
+    for (const auto& d : m_devices)
+      d->ResetInput();
+  }
+  else
+  {
+    for (const auto& d : m_devices)
+    {
+      // This isn't 100% right as other input channels could still be changing the outputs but
+      // as of now that could never happen and even so, it's still better than stuck output values
+      d->ResetOutput();
+    }
+  }
+
+  tls_input_channel = prev_input_channel;
 }
 
 void ControllerInterface::SetAspectRatioAdjustment(float value)
@@ -435,7 +504,7 @@ Common::Vec2 ControllerInterface::GetWindowInputScale() const
 }
 
 // Register a callback to be called when a device is added or removed (as from the input backends'
-// hotplug thread), or when devices are refreshed
+// hotplug thread), or when devices are refreshed.
 // Returns a handle for later removing the callback.
 ControllerInterface::HotplugCallbackHandle
 ControllerInterface::RegisterDevicesChangedCallback(std::function<void()> callback)
@@ -460,4 +529,29 @@ void ControllerInterface::InvokeDevicesChangedCallbacks() const
   m_callbacks_mutex.unlock();
   for (const auto& callback : devices_changed_callbacks)
     callback();
+}
+
+ciface::InputChannel ControllerInterface::GetCurrentInputChannel()
+{
+  return tls_input_channel;
+}
+
+double ControllerInterface::GetCurrentInputDeltaSeconds()
+{
+  return s_input_channels_delta_seconds[u8(tls_input_channel)];
+}
+
+double ControllerInterface::GetTargetInputDeltaSeconds()
+{
+  return s_input_channels_target_delta_seconds[u8(tls_input_channel)];
+}
+
+s32 ControllerInterface::GetInputUpdatesPerTarget()
+{
+  return s_input_channels_updates_per_target[u8(tls_input_channel)];
+}
+
+double ControllerInterface::GetCurrentRealInputDeltaSeconds()
+{
+  return s_input_channels_real_delta_seconds[u8(tls_input_channel)];
 }

--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -13,7 +14,10 @@
 
 #include "Common/CommonTypes.h"
 
-// idk in case I wanted to change it to double or something, idk what's best
+#include "InputCommon/ControllerInterface/InputChannel.h"
+
+// idk in case I wanted to change it from double or something, idk what's best,
+// but code assumes it's double now
 typedef double ControlState;
 
 namespace ciface
@@ -47,17 +51,59 @@ public:
   //
   // Control includes inputs and outputs
   //
-  class Control  // input or output
+  class Control
   {
   public:
     virtual ~Control() = default;
     virtual std::string GetName() const = 0;
     virtual Input* ToInput() { return nullptr; }
     virtual Output* ToOutput() { return nullptr; }
+    virtual void ResetState() {}
 
     // May be overridden to allow multiple valid names.
     // Useful for backwards-compatible configurations when names change.
     virtual bool IsMatchingName(std::string_view name) const;
+  };
+
+  // A set of flags we can define to determine whether a Control should be
+  // read (or written), or ignored/blocked, based on our current game app/window focus.
+  // They are in order of priority, and some of them are mutually exclusive.
+  //
+  // These flags are per Control on inputs, but they will ultimately be managed by
+  // ControlReference expressions. This is because pre-filtering Controls indivudally
+  // would have been too complicated, expensive, and ultimately, useless.
+  // Outputs don't implement GetFocusFlags() because they all default to the IgnoreFocus,
+  // see ControlExpression for more.
+  //
+  // Users can use expressions to customize the focus requirements of any input/output
+  // ControlReference, but we manually hardcode them in some Inputs (e.g. mouse) so
+  // users don't have to bother in most cases, as it's easy to understand as a concept.
+  enum class FocusFlags : u8
+  {
+    // The control only passes if we have focus (or the user accepts background input).
+    RequireFocus = 0x01,
+    // The control only passes if we have "full" focus, which means the cursor
+    // has been locked into the game window. Ignored if cursor locking is off.
+    RequireFullFocus = 0x02,
+    // Some inputs are able to make you lose or gain focus or full focus,
+    // for example a mouse click, or the Windows/Esc key. When these are pressed
+    // and there is a window focus change, ignore them for the time being, as the
+    // user didn't want the application to react. It basically blocks them until release,
+    // meaning they will return 0. Ignored on outputs because it just isn't necessary.
+    // Shouldn't be used without RequireFocus or RequireFullFocus.
+    // Note that this won't 100% work with "Pause On Focus Loss" due to the ControlReference
+    // gate not updating when the emulation is not running.
+    IgnoreOnFocusChanged = 0x04,
+    // Forces the control to pass even if we have no focus, useful for things like battery level.
+    // This is not 0 because it needs higher priority over other flags.
+    IgnoreFocus = 0x80,
+
+    // Even expressions that have a fixed value should return this by default, as their focus can
+    // be ignored by other means and users have the ability to ignore it with other functions.
+    // Default for inputs and outputs, except for output ControlReference.
+    Default = RequireFocus,
+    // Outputs ignore focus by default. Change it here if desired.
+    OutputDefault = IgnoreFocus
   };
 
   //
@@ -72,15 +118,17 @@ public:
     // undesirable behavior in our mapping logic.
     virtual bool IsDetectable() const { return true; }
 
+    virtual FocusFlags GetFocusFlags() const { return FocusFlags::Default; }
+
     // Implementations should return a value from 0.0 to 1.0 across their normal range.
     // One input should be provided for each "direction". (e.g. 2 for each axis)
-    // If possible, negative values may be returned in situations where an opposing input is
-    // activated. (e.g. When an underlying axis, X, is currently negative, "Axis X-", will return a
-    // positive value and "Axis X+" may return a negative value.)
+    // If possible, negative values may be returned in situations where an opposing input
+    // is activated. (e.g. When an underlying axis, X, is currently negative, "Axis X-",
+    // will return a positive value and "Axis X+" may return a negative value.)
     // Doing so is solely to allow our input detection logic to better detect false positives.
     // This is necessary when making use of "FullAnalogSurface" as multiple inputs will be seen
-    // increasing from 0.0 to 1.0 as a user tries to map just one. The negative values provide a
-    // view of the underlying axis. (Negative values are clamped off before they reach
+    // increasing from 0.0 to 1.0 as a user tries to map just one. The negative values provide
+    // a view of the underlying axis. (Negative values are clamped off before they reach
     // expression-parser or controller-emu)
     virtual ControlState GetState() const = 0;
 
@@ -90,25 +138,100 @@ public:
     // so hotkey logic knows Ctrl, L_Ctrl, and R_Ctrl are the same,
     // and so input detection can return the parent name.
     virtual bool IsChild(const Input*) const { return false; }
+
+  protected:
+    InputChannel GetCurrentInputChannel() const;
   };
 
+  //
+  // RelativeInput
+  //
+  // Helper to generate a relative input from an absolute one.
+  // Keeps the last 2 absolute states and returns their difference.
+  // It has one state per input channel, as otherwise one SetState() would break
+  // GetState() on the other channels.
+  // This is not directly mappable to analog sticks, there are function expressions for that.
+  // m_scale is useful to automatically scale the input to a usable value by the emulation.
+  // You don't have to use this implementation.
+  //
+  template <typename T = ControlState>
   class RelativeInput : public Input
   {
   public:
-    bool IsDetectable() const override { return false; }
+    RelativeInput(ControlState scale = 1.0) : m_scale(scale) {}
+
+    void UpdateState(T absolute_state)
+    {
+      RelativeInputState& state = m_states[u8(GetCurrentInputChannel())];
+      state.relative_state =
+          state.initialized ? ControlState(absolute_state - state.absolute_state) : 0.0;
+      state.absolute_state = absolute_state;
+      state.initialized = true;
+    }
+    void ResetState() override
+    {
+      RelativeInputState& state = m_states[u8(GetCurrentInputChannel())];
+      state.relative_state = 0.0;
+      state.initialized = false;
+    }
+    // Different input channels are never updated concurrently so you can
+    // safely call this the first time your devices loses/resets its absolute value
+    void ResetAllStates()
+    {
+      for (u8 i = 0; i < std::size(m_states); ++i)
+      {
+        RelativeInputState& state = m_states[i];
+        state.relative_state = 0.0;
+        state.initialized = false;
+      }
+    }
+    T GetAbsoluteState() const
+    {
+      RelativeInputState& state = m_states[u8(GetCurrentInputChannel())];
+      return state.initialized ? state.absolute_state : T(0);
+    }
+    ControlState GetState() const override
+    {
+      const RelativeInputState& state = m_states[u8(GetCurrentInputChannel())];
+      return state.relative_state * m_scale;
+    }
+
+  protected:
+    struct RelativeInputState
+    {
+      T absolute_state;
+      ControlState relative_state = 0.0;
+      bool initialized = false;
+    };
+
+    RelativeInputState m_states[u8(InputChannel::Max)];
+    // Not really necessary but it helps to add transparency to the final user,
+    // we need a multiplier to have the relative values usable. Can also be used as range
+    const ControlState m_scale;
   };
 
   //
   // Output
   //
-  // An output on a device
+  // An output on a device.
+  // State 0 is expected to be the resting value.
+  // It has a map of states as different objects can set its value.
+  // The sum of all the states will be used as output.
+  // You are responsible of calling SetState(0, source_object) after calling it with any other val.
+  // SetState() and ResetState() need GetDevicesOutputLock().
   //
   class Output : public Control
   {
   public:
     virtual ~Output() = default;
-    virtual void SetState(ControlState state) = 0;
+    void SetState(ControlState state, const void* source_object);
     Output* ToOutput() override { return this; }
+    void ResetState() override;
+
+  private:
+    virtual void SetStateInternal(ControlState state) = 0;
+    std::map<const void*, ControlState> m_states;
+    ControlState m_final_state = 0;
   };
 
   virtual ~Device();
@@ -118,7 +241,10 @@ public:
   virtual std::string GetName() const = 0;
   virtual std::string GetSource() const = 0;
   std::string GetQualifiedName() const;
+  // Outputs are instead set and updated in different places
   virtual void UpdateInput() {}
+  void ResetInput();
+  void ResetOutput();
 
   // May be overridden to implement hotplug removal.
   // Currently handled on a per-backend basis but this could change.
@@ -229,6 +355,8 @@ public:
   std::string GetDefaultDeviceString() const;
   std::shared_ptr<Device> FindDevice(const DeviceQualifier& devq) const;
 
+  std::unique_lock<std::mutex> GetDevicesOutputLock() const;
+
   bool HasConnectedDevice(const DeviceQualifier& qualifier) const;
 
   std::vector<InputDetection> DetectInput(const std::vector<std::string>& device_strings,
@@ -239,6 +367,8 @@ public:
 protected:
   // Exclusively needed when reading/writing "m_devices"
   mutable std::recursive_mutex m_devices_mutex;
+  // Needed when setting values/state on outputs
+  mutable std::mutex m_devices_output_mutex;
   std::vector<std::shared_ptr<Device>> m_devices;
 };
 }  // namespace Core

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.cpp
@@ -42,7 +42,16 @@ const Config::Info<bool> SERVERS_ENABLED{{Config::System::DualShockUDPClient, "S
 // Clock type used for querying timeframes
 using SteadyClock = std::chrono::steady_clock;
 
-class Device final : public Core::Device
+std::atomic<int> g_calibration_device_index = -1;
+bool g_calibration_device_found = false;
+s16 g_calibration_touch_x_min = std::numeric_limits<s16>::max();
+s16 g_calibration_touch_y_min = std::numeric_limits<s16>::max();
+s16 g_calibration_touch_x_max = std::numeric_limits<s16>::min();
+s16 g_calibration_touch_y_max = std::numeric_limits<s16>::min();
+
+constexpr ControlState TOUCH_SPEED = 0.0125;  // Just a value that seemed good
+
+class UDPDevice final : public Core::Device
 {
 private:
   template <class T>
@@ -62,12 +71,13 @@ private:
     const T m_mask;
   };
 
-  template <class T>
+  template <class T = ControlState>
   class AnalogInput : public Input
   {
   public:
-    AnalogInput(const char* name, const T& input, ControlState range, ControlState offset = 0)
-        : m_name(name), m_input(input), m_range(range), m_offset(offset)
+    AnalogInput(const char* name, const T& input, ControlState range, ControlState offset = 0,
+                std::string_view old_name = "")
+        : m_name(name), m_input(input), m_range(range), m_offset(offset), m_old_name(old_name)
     {
     }
     std::string GetName() const final override { return m_name; }
@@ -75,15 +85,33 @@ private:
     {
       return (ControlState(m_input) + m_offset) / m_range;
     }
+    bool IsMatchingName(std::string_view name) const override
+    {
+      if (Input::IsMatchingName(name))
+        return true;
+
+      return m_old_name == name;
+    }
 
   private:
     const char* m_name;
     const T& m_input;
     const ControlState m_range;
     const ControlState m_offset;
+    const std::string_view m_old_name;
   };
 
-  class TouchInput final : public AnalogInput<int>
+  class RelativeTouchInput final : public RelativeInput<s16>
+  {
+  public:
+    RelativeTouchInput(const char* name, ControlState scale) : RelativeInput(scale), m_name(name) {}
+    std::string GetName() const final override { return m_name; }
+
+  private:
+    const char* m_name;
+  };
+
+  class TouchInput final : public AnalogInput<>
   {
   public:
     using AnalogInput::AnalogInput;
@@ -127,10 +155,67 @@ private:
     const BatteryState& m_battery;
   };
 
+  // Names are based on DS4 for simplicity
+  struct DeviceInputNames
+  {
+    DeviceInputNames(const char* up, const char* down, const char* left, const char* right,
+                     const char* square, const char* cross, const char* circle,
+                     const char* triangle, const char* l1, const char* r1, const char* l2,
+                     const char* r2, const char* l3, const char* r3, const char* share,
+                     const char* options, const char* ps)
+        : m_up(up), m_down(down), m_left(left), m_right(right), m_square(square), m_cross(cross),
+          m_circle(circle), m_triangle(triangle), m_l1(l1), m_r1(r1), m_l2(l2), m_r2(r2), m_l3(l3),
+          m_r3(r3), m_share(share), m_options(options), m_ps(ps)
+    {
+    }
+    const char* m_up;
+    const char* m_down;
+    const char* m_left;
+    const char* m_right;
+    const char* m_square;
+    const char* m_cross;
+    const char* m_circle;
+    const char* m_triangle;
+    const char* m_l1;
+    const char* m_r1;
+    const char* m_l2;
+    const char* m_r2;
+    const char* m_l3;
+    const char* m_r3;
+    const char* m_share;
+    const char* m_options;
+    const char* m_ps;
+  };
+
+  static constexpr std::string_view DS4_INPUT_NAME = "DS4";
+  static constexpr std::string_view DUALSENSE_INPUT_NAME = "DualSense";
+  static constexpr std::string_view SWITCH_INPUT_NAME = "Switch";
+  static constexpr std::string_view GENERIC_INPUT_NAME = "Generic";
+
+  // Sure it would be nice if they were filled in from a config but this is fine
+  const std::map<std::string_view, const DeviceInputNames> g_input_names_by_device = {
+      {DS4_INPUT_NAME,
+       DeviceInputNames("Up", "Down", "Left", "Right", "Square", "Cross", "Circle", "Triangle",
+                        "L1", "R1", "L2", "R2", "L3", "R3", "Share", "Options", "PS")},
+      {DUALSENSE_INPUT_NAME,
+       DeviceInputNames("Up", "Down", "Left", "Right", "Square", "Cross", "Circle", "Triangle",
+                        "L1", "R1", "L2", "R2", "L3", "R3", "Create", "Options", "PS")},
+      {SWITCH_INPUT_NAME,
+       DeviceInputNames("Up", "Down", "Left", "Right", "Y", "B", "A", "X", "L", "R", "ZL", "ZR",
+                        "Left Stick", "Right Stick", "-", "+", "Home")},
+      // Mandatory. Assume orientation of D-Pad and "action" buttons but not of central buttons
+      {GENERIC_INPUT_NAME,
+       DeviceInputNames("D-Pad N", "D-Pad S", "D-Pad W", "D-Pad E", "Button W", "Button S",
+                        "Button E", "Button N", "Left Bumper", "Right Bumper", "Left Trigger",
+                        "Right Trigger", "Left Stick", "Right Stick", "Special Button 1",
+                        "Special Button 2", "Special Button 3")}};
+
 public:
   void UpdateInput() override;
 
-  Device(std::string name, int index, std::string server_address, u16 server_port);
+  UDPDevice(std::string name, int index, std::string server_address, u16 server_port,
+            std::string device_type = "", std::string calibration = "",
+            bool for_calibration = false);
 
   std::string GetName() const final override;
   std::string GetSource() const final override;
@@ -145,13 +230,15 @@ private:
   const int m_index;
   sf::UdpSocket m_socket;
   SteadyClock::time_point m_next_reregister = SteadyClock::time_point::min();
-  Proto::MessageType::PadDataResponse m_pad_data{};
-  Proto::Touch m_prev_touch{};
-  bool m_prev_touch_valid = false;
-  int m_touch_x = 0;
-  int m_touch_y = 0;
+  SteadyClock::time_point m_last_update;
+  Proto::MessageType::PadDataResponse m_pad_data;
+  ControlState m_touch_x;
+  ControlState m_touch_y;
+  Proto::Touch m_prev_touches[u8(InputChannel::Max)];
+  RelativeTouchInput* m_relative_touch_inputs[4];
   std::string m_server_address;
   u16 m_server_port;
+  bool m_for_calibration;
 
   s16 m_touch_x_min;
   s16 m_touch_y_min;
@@ -162,16 +249,17 @@ private:
 using MathUtil::GRAVITY_ACCELERATION;
 constexpr auto SERVER_REREGISTER_INTERVAL = std::chrono::seconds{1};
 constexpr auto SERVER_LISTPORTS_INTERVAL = std::chrono::seconds{1};
-constexpr int TOUCH_X_AXIS_MAX = 1000;
-constexpr int TOUCH_Y_AXIS_MAX = 500;
 constexpr auto THREAD_MAX_WAIT_INTERVAL = std::chrono::milliseconds{250};
 constexpr auto SERVER_UNRESPONSIVE_INTERVAL = std::chrono::seconds{1};  // Can be 0
+constexpr auto RESET_INPUT_INTERVAL = std::chrono::seconds{1};
 constexpr u32 SERVER_ASKED_PADS = 4;
 
 struct Server
 {
-  Server(std::string description, std::string address, u16 port)
-      : m_description{std::move(description)}, m_address{std::move(address)}, m_port{port}
+  Server(std::string description, std::string address, u16 port, std::string device_type = "",
+         std::string calibration = "")
+      : m_description{std::move(description)}, m_address{std::move(address)}, m_port{port},
+        m_device_type{std::move(device_type)}, m_calibration{std::move(calibration)}
   {
   }
   Server(const Server&) = delete;
@@ -193,6 +281,8 @@ struct Server
   u16 m_port;
   std::array<Proto::MessageType::PortInfo, Proto::PORT_COUNT> m_port_info;
   sf::UdpSocket m_socket;
+  std::string m_device_type;
+  std::string m_calibration;
   SteadyClock::time_point m_disconnect_time = SteadyClock::now();
 };
 
@@ -397,14 +487,23 @@ static void ConfigChanged()
   const bool servers_enabled = Config::Get(Settings::SERVERS_ENABLED);
   const std::string servers_setting = Config::Get(Settings::SERVERS);
 
-  std::string new_servers_setting;
+  std::string old_servers_setting;
   for (const auto& server : s_servers)
   {
-    new_servers_setting +=
-        fmt::format("{}:{}:{};", server.m_description, server.m_address, server.m_port);
+    // These are only useful to make sure we won't restart the thread unless
+    // servers have actually changed, and to keep some flexibility in the serialization
+    std::string format_string = "{}:{}:{}";
+    if (!server.m_calibration.empty())
+      format_string += ":{}:({})";
+    else if (!server.m_device_type.empty())
+      format_string += ":{}";
+    format_string += ";";
+    old_servers_setting += fmt::format(format_string, server.m_description, server.m_address,
+                                       server.m_port, server.m_device_type, server.m_calibration);
   }
 
-  if (servers_enabled != s_servers_enabled || servers_setting != new_servers_setting)
+  if (servers_enabled != s_servers_enabled || servers_setting != old_servers_setting ||
+      g_calibration_device_index >= 0)
   {
     // Stop the thread before writing to s_servers
     StopHotplugThread();
@@ -422,13 +521,20 @@ static void ConfigChanged()
       const std::string description = server_info[0];
       const std::string server_address = server_info[1];
       const auto port = std::stoi(server_info[2]);
+      const std::string device_type = server_info.size() > 3 ? server_info[3] : "";
+      std::string calibration = server_info.size() > 4 ? server_info[4] : "";
+      // Remove '(' and ')'
+      if (!calibration.empty())
+        calibration.erase(0, 1);
+      if (!calibration.empty())
+        calibration.pop_back();
       if (port >= std::numeric_limits<u16>::max())
       {
         continue;
       }
       u16 server_port = static_cast<u16>(port);
 
-      s_servers.emplace_back(description, server_address, server_port);
+      s_servers.emplace_back(description, server_address, server_port, device_type, calibration);
     }
     Restart();
   }
@@ -445,6 +551,7 @@ void Init()
 
   if (!server_address_setting.empty() && server_port_setting != 0)
   {
+    // We have added even more settings now but they don't have to be defined
     const auto& servers_setting = Config::Get(ciface::DualShockUDPClient::Settings::SERVERS);
     Config::SetBaseOrCurrent(ciface::DualShockUDPClient::Settings::SERVERS,
                              servers_setting + fmt::format("{}:{}:{};", "DS4",
@@ -473,6 +580,7 @@ void PopulateDevices()
   g_controller_interface.RemoveDevice(
       [](const auto* dev) { return dev->GetSource() == DUALSHOCKUDP_SOURCE_NAME; });
 
+  int i = 0;
   // Users might have created more than one server on the same IP/Port.
   // Devices might end up being duplicated (if the server responds two all requests)
   // but they won't conflict.
@@ -484,9 +592,13 @@ void PopulateDevices()
       if (port_info.pad_state != Proto::DsState::Connected)
         continue;
 
-      g_controller_interface.AddDevice(std::make_shared<Device>(
-          server.m_description, static_cast<int>(port_index), server.m_address, server.m_port));
+      // In case we create more than one device from a server, calibration should still work
+      // but it will be unique to the server and not the pads
+      g_controller_interface.AddDevice(std::make_shared<UDPDevice>(
+          server.m_description, static_cast<int>(port_index), server.m_address, server.m_port,
+          server.m_device_type, server.m_calibration, g_calibration_device_index == i));
     }
+    ++i;
   }
 }
 
@@ -499,31 +611,81 @@ void DeInit()
   s_servers.clear();
 }
 
-Device::Device(std::string name, int index, std::string server_address, u16 server_port)
+UDPDevice::UDPDevice(std::string name, int index, std::string server_address, u16 server_port,
+                     std::string device_type, std::string calibration, bool for_calibration)
     : m_name{std::move(name)}, m_index{index}, m_server_address{std::move(server_address)},
-      m_server_port{server_port}
+      m_server_port{server_port}, m_for_calibration(for_calibration)
 {
+  // We didn't have this setting before, so just default to DS4 as all the mapping would have been
+  // added as that
+  bool backwards_compatibility = false;
+  if (device_type.empty())
+  {
+    device_type = DS4_INPUT_NAME;
+    backwards_compatibility = true;
+  }
+  // Start from the default DS4 calibration (confirmed). Given that the DSU protocol offers no max
+  // for touch, other non DS4 implementation could have a different range.
+  m_touch_x_min = 0;
+  m_touch_y_min = 0;
+  m_touch_x_max = 1919;
+  m_touch_y_max = (device_type == DUALSENSE_INPUT_NAME) ? 1079 : 941;
+  const auto server_info = SplitString(calibration, ',');
+  if (server_info.size() >= 4)
+  {
+    m_touch_x_min = std::stoi(server_info[0]);
+    m_touch_y_min = std::stoi(server_info[1]);
+    m_touch_x_max = std::stoi(server_info[2]);
+    m_touch_y_max = std::stoi(server_info[3]);
+  }
+
   m_socket.setBlocking(false);
 
-  AddInput(new AnalogInput<u8>("Pad W", m_pad_data.button_dpad_left_analog, 255));
-  AddInput(new AnalogInput<u8>("Pad S", m_pad_data.button_dpad_down_analog, 255));
-  AddInput(new AnalogInput<u8>("Pad E", m_pad_data.button_dpad_right_analog, 255));
-  AddInput(new AnalogInput<u8>("Pad N", m_pad_data.button_dpad_up_analog, 255));
-  AddInput(new AnalogInput<u8>("Square", m_pad_data.button_square_analog, 255));
-  AddInput(new AnalogInput<u8>("Cross", m_pad_data.button_cross_analog, 255));
-  AddInput(new AnalogInput<u8>("Circle", m_pad_data.button_circle_analog, 255));
-  AddInput(new AnalogInput<u8>("Triangle", m_pad_data.button_triangle_analog, 255));
-  AddInput(new AnalogInput<u8>("L1", m_pad_data.button_l1_analog, 255));
-  AddInput(new AnalogInput<u8>("R1", m_pad_data.button_r1_analog, 255));
+  ResetPadData();
 
-  AddInput(new AnalogInput<u8>("L2", m_pad_data.trigger_l2, 255));
-  AddInput(new AnalogInput<u8>("R2", m_pad_data.trigger_r2, 255));
+  m_last_update = SteadyClock::now();
 
-  AddInput(new Button<u8>("L3", m_pad_data.button_states1, 0x2));
-  AddInput(new Button<u8>("R3", m_pad_data.button_states1, 0x4));
-  AddInput(new Button<u8>("Share", m_pad_data.button_states1, 0x1));
-  AddInput(new Button<u8>("Options", m_pad_data.button_states1, 0x8));
-  AddInput(new Button<u8>("PS", m_pad_data.button_ps, 0x1));
+  const DeviceInputNames* input_names;
+  auto it = g_input_names_by_device.find(device_type);
+  if (it != g_input_names_by_device.end())
+    input_names = &it->second;
+  else  // Generic profile is always available
+    input_names = &g_input_names_by_device.at(GENERIC_INPUT_NAME);
+
+  // Old names weren't following actual DS4 naming, make sure current configs are not broken
+  if (backwards_compatibility)
+  {
+    AddInput(
+        new AnalogInput<u8>(input_names->m_up, m_pad_data.button_dpad_up_analog, 255, 0, "Pad N"));
+    AddInput(new AnalogInput<u8>(input_names->m_down, m_pad_data.button_dpad_down_analog, 255, 0,
+                                 "Pad S"));
+    AddInput(new AnalogInput<u8>(input_names->m_left, m_pad_data.button_dpad_left_analog, 255, 0,
+                                 "Pad W"));
+    AddInput(new AnalogInput<u8>(input_names->m_right, m_pad_data.button_dpad_right_analog, 255, 0,
+                                 "Pad E"));
+  }
+  else
+  {
+    AddInput(new AnalogInput<u8>(input_names->m_up, m_pad_data.button_dpad_up_analog, 255));
+    AddInput(new AnalogInput<u8>(input_names->m_down, m_pad_data.button_dpad_down_analog, 255));
+    AddInput(new AnalogInput<u8>(input_names->m_left, m_pad_data.button_dpad_left_analog, 255));
+    AddInput(new AnalogInput<u8>(input_names->m_right, m_pad_data.button_dpad_right_analog, 255));
+  }
+  AddInput(new AnalogInput<u8>(input_names->m_square, m_pad_data.button_square_analog, 255));
+  AddInput(new AnalogInput<u8>(input_names->m_cross, m_pad_data.button_cross_analog, 255));
+  AddInput(new AnalogInput<u8>(input_names->m_circle, m_pad_data.button_circle_analog, 255));
+  AddInput(new AnalogInput<u8>(input_names->m_triangle, m_pad_data.button_triangle_analog, 255));
+  AddInput(new AnalogInput<u8>(input_names->m_l1, m_pad_data.button_l1_analog, 255));
+  AddInput(new AnalogInput<u8>(input_names->m_r1, m_pad_data.button_r1_analog, 255));
+
+  AddInput(new AnalogInput<u8>(input_names->m_l2, m_pad_data.trigger_l2, 255));
+  AddInput(new AnalogInput<u8>(input_names->m_r2, m_pad_data.trigger_r2, 255));
+
+  AddInput(new Button<u8>(input_names->m_l3, m_pad_data.button_states1, 0x2));
+  AddInput(new Button<u8>(input_names->m_r3, m_pad_data.button_states1, 0x4));
+  AddInput(new Button<u8>(input_names->m_share, m_pad_data.button_states1, 0x1));
+  AddInput(new Button<u8>(input_names->m_options, m_pad_data.button_states1, 0x8));
+  AddInput(new Button<u8>(input_names->m_ps, m_pad_data.button_ps, 0x1));
   AddInput(new Button<u8>("Touch Button", m_pad_data.button_touch, 0x1));
 
   AddInput(new AnalogInput<u8>("Left X-", m_pad_data.left_stick_x, -128, -128));
@@ -535,10 +697,23 @@ Device::Device(std::string name, int index, std::string server_address, u16 serv
   AddInput(new AnalogInput<u8>("Right Y-", m_pad_data.right_stick_y_inverted, -128, -128));
   AddInput(new AnalogInput<u8>("Right Y+", m_pad_data.right_stick_y_inverted, 127, -128));
 
-  AddInput(new TouchInput("Touch X-", m_touch_x, -TOUCH_X_AXIS_MAX));
-  AddInput(new TouchInput("Touch X+", m_touch_x, TOUCH_X_AXIS_MAX));
-  AddInput(new TouchInput("Touch Y-", m_touch_y, -TOUCH_Y_AXIS_MAX));
-  AddInput(new TouchInput("Touch Y+", m_touch_y, TOUCH_Y_AXIS_MAX));
+  m_relative_touch_inputs[0] = new RelativeTouchInput("Relative Touch X-", -TOUCH_SPEED);
+  m_relative_touch_inputs[1] = new RelativeTouchInput("Relative Touch X+", TOUCH_SPEED);
+  m_relative_touch_inputs[2] = new RelativeTouchInput("Relative Touch Y-", -TOUCH_SPEED);
+  m_relative_touch_inputs[3] = new RelativeTouchInput("Relative Touch Y+", TOUCH_SPEED);
+  AddInput(m_relative_touch_inputs[0]);
+  AddInput(m_relative_touch_inputs[1]);
+  AddInput(m_relative_touch_inputs[2]);
+  AddInput(m_relative_touch_inputs[3]);
+
+  ControlState touch_x_range = (m_touch_x_max - m_touch_x_min) / 2.0;
+  ControlState touch_x_offset = -(m_touch_x_min + touch_x_range);
+  ControlState touch_y_range = (m_touch_y_max - m_touch_y_min) / 2.0;
+  ControlState touch_y_offset = -(m_touch_y_min + touch_y_range);
+  AddInput(new TouchInput("Touch X-", m_touch_x, -touch_x_range, touch_x_offset));
+  AddInput(new TouchInput("Touch X+", m_touch_x, touch_x_range, touch_x_offset));
+  AddInput(new TouchInput("Touch Y-", m_touch_y, -touch_y_range, touch_y_offset));
+  AddInput(new TouchInput("Touch Y+", m_touch_y, touch_y_range, touch_y_offset));
 
   // Convert Gs to meters per second squared
   constexpr auto accel_scale = 1.0 / GRAVITY_ACCELERATION;
@@ -561,18 +736,16 @@ Device::Device(std::string name, int index, std::string server_address, u16 serv
   AddInput(new GyroInput("Gyro Yaw Right", m_pad_data.gyro_yaw_deg_s, gyro_scale));
 
   AddInput(new BatteryInput(m_pad_data.battery_status));
-
-  m_touch_x_min = 0;
-  m_touch_y_min = 0;
-  // DS4 touchpad max values
-  m_touch_x_max = 1919;
-  m_touch_y_max = 941;
-
-  ResetPadData();
 }
 
-void Device::ResetPadData()
+void UDPDevice::ResetPadData()
 {
+  for (size_t i = 0; i < std::size(m_prev_touches); ++i)
+  {
+    m_prev_touches[i].active = false;
+    m_prev_touches[i].id = 0;
+  }
+
   m_pad_data = Proto::MessageType::PadDataResponse{};
 
   // Make sure they start from resting values, not from 0
@@ -586,17 +759,17 @@ void Device::ResetPadData()
   m_pad_data.touch1.y = m_touch_y;
 }
 
-std::string Device::GetName() const
+std::string UDPDevice::GetName() const
 {
   return m_name;
 }
 
-std::string Device::GetSource() const
+std::string UDPDevice::GetSource() const
 {
   return std::string(DUALSHOCKUDP_SOURCE_NAME);
 }
 
-void Device::UpdateInput()
+void UDPDevice::UpdateInput()
 {
   // Regularly tell the UDP server to feed us controller data
   const auto now = SteadyClock::now();
@@ -621,30 +794,100 @@ void Device::UpdateInput()
   std::size_t received_bytes;
   sf::IpAddress sender;
   u16 port;
+  std::vector<Proto::MessageType::PadDataResponse> pad_datas;
   while (m_socket.receive(&msg, sizeof msg, received_bytes, sender, port) ==
          sf::Socket::Status::Done)
   {
     if (auto pad_data = msg.CheckAndCastTo<Proto::MessageType::PadDataResponse>())
     {
-      m_pad_data = *pad_data;
-
-      // Update touch pad relative coordinates
-      if (m_pad_data.touch1.id != m_prev_touch.id)
-        m_prev_touch_valid = false;
-      if (m_prev_touch_valid)
-      {
-        m_touch_x += m_pad_data.touch1.x - m_prev_touch.x;
-        m_touch_y += m_pad_data.touch1.y - m_prev_touch.y;
-        m_touch_x = std::clamp(m_touch_x, -TOUCH_X_AXIS_MAX, TOUCH_X_AXIS_MAX);
-        m_touch_y = std::clamp(m_touch_y, -TOUCH_Y_AXIS_MAX, TOUCH_Y_AXIS_MAX);
-      }
-      m_prev_touch = m_pad_data.touch1;
-      m_prev_touch_valid = true;
+      pad_datas.push_back(*pad_data);
     }
+  }
+
+  // Given that packages are not synchronized to our updates one input channel
+  // might receive all the new UDP packages while other channels get none, so we always update
+  // the state to the latest received state. Precision losses should be very minor though
+  // changes might be inconsistent.
+  // The only way to make this work would be to make and sum up delta from all the input channels
+  // and then commit the current sum of deltas as state in the update of your input channel.
+  const size_t pad_datas_original_size = pad_datas.size();
+  if (pad_datas_original_size > 0)
+  {
+    m_pad_data = pad_datas.back();
+    // This acts as "last touch" as we don't check pad_data.touch1.active,
+    // so the value persists after we stopped touching.
+    // This is because we likely want to use this to control the wiimote cursor,
+    // not as an analog stick, so we don't want the value to reset, also it's very easy for
+    // your fingers to touch the borders and accidentally end the touch.
+    m_touch_x = m_pad_data.touch1.x;
+    m_touch_y = m_pad_data.touch1.y;
+
+    if (m_for_calibration)
+    {
+      g_calibration_device_found = true;  // We don't set this as false on disconnect but it's fine
+      if (m_pad_data.touch1.active)
+      {
+        g_calibration_touch_x_min = std::min(m_pad_data.touch1.x, g_calibration_touch_x_min);
+        g_calibration_touch_y_min = std::min(m_pad_data.touch1.y, g_calibration_touch_y_min);
+        g_calibration_touch_x_max = std::max(m_pad_data.touch1.x, g_calibration_touch_x_max);
+        g_calibration_touch_y_max = std::max(m_pad_data.touch1.y, g_calibration_touch_y_max);
+      }
+    }
+  }
+  else
+  {
+    pad_datas.push_back(m_pad_data);
+  }
+
+  const u8 input_channel = u8(ControllerInterface::GetCurrentInputChannel());
+
+  for (size_t i = 0; i < pad_datas.size(); ++i)
+  {
+    const Proto::MessageType::PadDataResponse& pad_data = pad_datas[i];
+
+    if (pad_data.touch1.id != m_prev_touches[input_channel].id ||
+        !m_prev_touches[input_channel].active)
+    {
+      for (size_t k = 0; k < std::size(m_relative_touch_inputs); ++k)
+        m_relative_touch_inputs[k]->ResetState();
+    }
+    // Skip this update if the next touch has the same id, otherwise we'd lose the total deltas.
+    // Note that if we had more different touch ids within the same update, we'd lose all deltas
+    // except the last one.
+    else if (i + 1 < pad_datas.size())
+    {
+      const Proto::MessageType::PadDataResponse& next_pad_data = pad_datas[i + 1];
+      if (pad_data.touch1.id == next_pad_data.touch1.id)
+        continue;
+    }
+    m_relative_touch_inputs[0]->UpdateState(pad_data.touch1.x);
+    m_relative_touch_inputs[1]->UpdateState(pad_data.touch1.x);
+    m_relative_touch_inputs[2]->UpdateState(pad_data.touch1.y);
+    m_relative_touch_inputs[3]->UpdateState(pad_data.touch1.y);
+
+    m_prev_touches[input_channel] = pad_data.touch1;
+  }
+
+  if (pad_datas_original_size == 0)
+    pad_datas.clear();
+
+  // If we haven't received an update in the last x seconds, reset inputs
+  if (pad_datas.size() == 0 && (now - m_last_update) >= RESET_INPUT_INTERVAL)
+  {
+    ResetPadData();
+
+    for (size_t i = 0; i < std::size(m_relative_touch_inputs); ++i)
+      m_relative_touch_inputs[i]->ResetAllStates();
+
+    m_last_update = now;  // Don't re-reset immediately
+  }
+  else if (pad_datas.size() > 0)
+  {
+    m_last_update = now;
   }
 }
 
-std::optional<int> Device::GetPreferredId() const
+std::optional<int> UDPDevice::GetPreferredId() const
 {
   return m_index;
 }

--- a/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
+++ b/Source/Core/InputCommon/ControllerInterface/DualShockUDPClient/DualShockUDPClient.h
@@ -3,12 +3,22 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "Common/Config/Config.h"
 
 namespace ciface::DualShockUDPClient
 {
 constexpr char DEFAULT_SERVER_ADDRESS[] = "127.0.0.1";
 constexpr u16 DEFAULT_SERVER_PORT = 26760;
+
+// Hacky global way of doing calibration from UI
+extern std::atomic<int> g_calibration_device_index;
+extern bool g_calibration_device_found;
+extern s16 g_calibration_touch_x_min;
+extern s16 g_calibration_touch_y_min;
+extern s16 g_calibration_touch_x_max;
+extern s16 g_calibration_touch_y_max;
 
 namespace Settings
 {

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.cpp
@@ -214,6 +214,7 @@ ForceFeedbackDevice::TypedForce<P>::TypedForce(ForceFeedbackDevice* parent, cons
 template <typename P>
 void ForceFeedbackDevice::TypedForce<P>::UpdateEffect(int magnitude)
 {
+  // Only do if the value has changed
   if (UpdateParameters(magnitude))
   {
     if (magnitude)
@@ -234,12 +235,11 @@ ForceFeedbackDevice::Force::Force(ForceFeedbackDevice* parent, const char* name,
 {
 }
 
-void ForceFeedbackDevice::Force::SetState(ControlState state)
+void ForceFeedbackDevice::Force::SetStateInternal(ControlState state)
 {
-  const auto new_val = int(DI_FFNOMINALMAX * state);
-
-  if (m_desired_magnitude.exchange(new_val) != new_val)
-    m_parent.SignalUpdateThread();
+  m_desired_magnitude = int(DI_FFNOMINALMAX * state);
+  // Keep setting it even if the value hasn't changed to prevent it from stopping
+  m_parent.SignalUpdateThread();
 }
 
 void ForceFeedbackDevice::Force::UpdateOutput()

--- a/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/ForceFeedback/ForceFeedbackDevice.h
@@ -37,13 +37,13 @@ private:
     void UpdateOutput();
     void Release();
 
-    void SetState(ControlState state) override;
     std::string GetName() const override;
 
   protected:
     const LPDIRECTINPUTEFFECT m_effect;
 
   private:
+    void SetStateInternal(ControlState state) override;
     virtual void UpdateEffect(int magnitude) = 0;
 
     ForceFeedbackDevice& m_parent;

--- a/Source/Core/InputCommon/ControllerInterface/InputChannel.h
+++ b/Source/Core/InputCommon/ControllerInterface/InputChannel.h
@@ -1,0 +1,20 @@
+// Copyright 2021 Dolphin Emulator Project
+// Licensed under GPLv2+
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "Common/CommonTypes.h"
+
+namespace ciface
+{
+// Assumed to be u8. Actually used for output as well
+enum class InputChannel : u8
+{
+  SerialInterface,  // GC Controllers
+  Bluetooth,        // Wiimote and other BT devices
+  Host,             // Hotkeys (worker thread) and UI (game input config panels, main thread)
+  FreeLook,
+  Max
+};
+}  // namespace ciface

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -37,6 +37,10 @@ private:
     std::string GetName() const override;
     bool IsDetectable() const override { return false; }
     ControlState GetState() const override;
+    FocusFlags GetFocusFlags() const override
+    {
+      return FocusFlags((u8(FocusFlags::RequireFocus) | u8(FocusFlags::RequireFullFocus)));
+    }
 
   private:
     const float& m_axis;
@@ -50,6 +54,11 @@ private:
     explicit Button(CGMouseButton button) : m_button(button) {}
     std::string GetName() const override;
     ControlState GetState() const override;
+    FocusFlags GetFocusFlags() const override
+    {
+      return FocusFlags(u8(FocusFlags::RequireFocus) | u8(FocusFlags::RequireFullFocus) |
+                        u8(FocusFlags::IgnoreOnFocusChanged));
+    }
 
   private:
     CGMouseButton m_button;

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.cpp
@@ -377,15 +377,14 @@ std::string Joystick::LeftRightEffect::GetName() const
   return (Motor::Strong == m_motor) ? "Strong" : "Weak";
 }
 
-void Joystick::HapticEffect::SetState(ControlState state)
+void Joystick::HapticEffect::SetStateInternal(ControlState state)
 {
   // Maximum force value for all SDL effects:
   constexpr s16 MAX_FORCE_VALUE = 0x7fff;
 
-  if (UpdateParameters(s16(state * MAX_FORCE_VALUE)))
-  {
-    UpdateEffect();
-  }
+  UpdateParameters(s16(state * MAX_FORCE_VALUE));
+  // Keep setting it even if the value hasn't changed to prevent it from stopping
+  UpdateEffect();
 }
 
 bool Joystick::ConstantEffect::UpdateParameters(s16 value)

--- a/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
+++ b/Source/Core/InputCommon/ControllerInterface/SDL/SDL.h
@@ -80,7 +80,7 @@ private:
     static constexpr u16 DISABLED_EFFECT_TYPE = 0;
 
   private:
-    virtual void SetState(ControlState state) override final;
+    virtual void SetStateInternal(ControlState state) override final;
     void UpdateEffect();
     SDL_Haptic* const m_haptic;
     int m_id = -1;

--- a/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
@@ -786,7 +786,7 @@ void InputDevice::AxisEvent(int axis, float value)
   }
 }
 
-bool InputDevice::ButtonValue(int pad_id, ButtonType button) const
+bool InputDevice::ButtonValue(int pad_id, ButtonType button)
 {
   const auto binding = m_input_binds.find(std::make_pair(pad_id, button));
   if (binding == m_input_binds.end())
@@ -808,7 +808,7 @@ bool InputDevice::ButtonValue(int pad_id, ButtonType button) const
   }
 }
 
-float InputDevice::AxisValue(int pad_id, ButtonType axis) const
+float InputDevice::AxisValue(int pad_id, ButtonType axis)
 {
   const auto binding = m_input_binds.find(std::make_pair(pad_id, axis));
   if (binding == m_input_binds.end())

--- a/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.h
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.h
@@ -262,8 +262,8 @@ public:
   }
   bool PressEvent(int button, int action);
   void AxisEvent(int axis, float value);
-  bool ButtonValue(int pad_id, ButtonType button) const;
-  float AxisValue(int pad_id, ButtonType axis) const;
+  bool ButtonValue(int pad_id, ButtonType button);
+  float AxisValue(int pad_id, ButtonType axis);
 };
 
 void Init(const std::string&);

--- a/Source/Core/InputCommon/ControllerInterface/Touch/Touchscreen.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/Touchscreen.cpp
@@ -244,7 +244,7 @@ std::string Touchscreen::Motor::GetName() const
   return ss.str();
 }
 
-void Touchscreen::Motor::SetState(ControlState state)
+void Touchscreen::Motor::SetStateInternal(ControlState state)
 {
   if (state > 0)
   {

--- a/Source/Core/InputCommon/ControllerInterface/Touch/Touchscreen.h
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/Touchscreen.h
@@ -44,9 +44,9 @@ private:
     Motor(int pad_id, ButtonManager::ButtonType index) : m_pad_id(pad_id), m_index(index) {}
     ~Motor();
     std::string GetName() const override;
-    void SetState(ControlState state) override;
 
   private:
+    void SetStateInternal(ControlState state) override;
     const int m_pad_id;
     const ButtonManager::ButtonType m_index;
     static void Rumble(int pad_id, double state);

--- a/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Wiimote/WiimoteController.cpp
@@ -85,9 +85,9 @@ public:
 
   std::string GetName() const override { return "Motor"; }
 
-  void SetState(ControlState state) override { m_value = state; }
-
 private:
+  void SetStateInternal(ControlState state) override { m_value = state; }
+
   std::atomic<ControlState>& m_value;
 };
 

--- a/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/XInput/XInput.cpp
@@ -94,17 +94,16 @@ public:
   }
 
   std::string GetName() const override { return named_motors[m_index]; }
-  void SetState(ControlState state) override
-  {
-    const auto old_value = m_motor;
-    m_motor = (WORD)(state * m_range);
-
-    // Only update if the state changed.
-    if (m_motor != old_value)
-      m_parent->UpdateMotors();
-  }
 
 private:
+  void SetStateInternal(ControlState state) override
+  {
+    m_motor = WORD(std::clamp(state, 0.0, 1.0) * m_range);
+    // We don't want to avoid setting this even if the values hasn't changed as
+    // XInput devices stop rumbling after a bit if we don't keep setting the same value
+    m_parent->UpdateMotors();
+  }
+
   WORD& m_motor;
   const WORD m_range;
   const u8 m_index;

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <vector>
 
 extern "C" {
 #include <X11/Xlib.h>
@@ -28,8 +29,7 @@ private:
     std::array<char, 32> keyboard;
     unsigned int buttons;
     Common::Vec2 cursor;
-    Common::Vec2 axis;
-    Common::Vec2 relative_mouse;
+    Common::DVec2 axis;
   };
 
   class Key : public Input
@@ -54,6 +54,11 @@ private:
     std::string GetName() const override { return name; }
     Button(unsigned int index, unsigned int* buttons);
     ControlState GetState() const override;
+    FocusFlags GetFocusFlags() const override
+    {
+      return FocusFlags(u8(FocusFlags::RequireFocus) | u8(FocusFlags::RequireFullFocus) |
+                        u8(FocusFlags::IgnoreOnFocusChanged));
+    }
 
   private:
     const unsigned int* m_buttons;
@@ -68,6 +73,10 @@ private:
     bool IsDetectable() const override { return false; }
     Cursor(u8 index, bool positive, const float* cursor);
     ControlState GetState() const override;
+    FocusFlags GetFocusFlags() const override
+    {
+      return FocusFlags((u8(FocusFlags::RequireFocus) | u8(FocusFlags::RequireFullFocus)));
+    }
 
   private:
     const float* m_cursor;
@@ -76,33 +85,18 @@ private:
     std::string name;
   };
 
-  class Axis : public Input
+  class Axis : public RelativeInput<double>
   {
   public:
     std::string GetName() const override { return name; }
-    bool IsDetectable() const override { return false; }
-    Axis(u8 index, bool positive, const float* axis);
-    ControlState GetState() const override;
+    Axis(ControlState scale, u8 index);
+    FocusFlags GetFocusFlags() const override
+    {
+      return FocusFlags(u8(FocusFlags::RequireFocus) | u8(FocusFlags::RequireFullFocus));
+    }
 
   private:
-    const float* m_axis;
     const u8 m_index;
-    const bool m_positive;
-    std::string name;
-  };
-
-  class RelativeMouse : public Input
-  {
-  public:
-    std::string GetName() const override { return name; }
-    bool IsDetectable() const override { return false; }
-    RelativeMouse(u8 index, bool positive, const float* axis);
-    ControlState GetState() const override;
-
-  private:
-    const float* m_axis;
-    const u8 m_index;
-    const bool m_positive;
     std::string name;
   };
 
@@ -123,6 +117,7 @@ private:
   Window m_window;
   Display* m_display;
   State m_state{};
+  std::vector<Axis*> m_mouse_axes;
   const int xi_opcode;
   const int pointer_deviceid;
   const int keyboard_deviceid;

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
@@ -717,13 +717,11 @@ std::string evdevDevice::RumbleEffect::GetName() const
   return (Motor::Strong == m_motor) ? "Strong" : "Weak";
 }
 
-void evdevDevice::Effect::SetState(ControlState state)
+void evdevDevice::Effect::SetStateInternal(ControlState state)
 {
-  if (UpdateParameters(state))
-  {
-    // Update effect if parameters changed.
-    UpdateEffect();
-  }
+  UpdateParameters(state);
+  // Keep setting it even if the value hasn't changed to prevent it from stopping
+  UpdateEffect();
 }
 
 void evdevDevice::Effect::UpdateEffect()

--- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
+++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.h
@@ -23,7 +23,6 @@ private:
   public:
     Effect(int fd);
     ~Effect();
-    void SetState(ControlState state) override;
 
   protected:
     virtual bool UpdateParameters(ControlState state) = 0;
@@ -33,6 +32,7 @@ private:
     static constexpr int DISABLED_EFFECT_TYPE = 0;
 
   private:
+    void SetStateInternal(ControlState state) override;
     void UpdateEffect();
 
     int const m_fd;


### PR DESCRIPTION
Squashed commits:

[a585272a3e] InputCommon: remove old comment that doesn't apply anymore (+115 squashed commit)

[5cf2047da3] Post rebase fixup

[edc29e3bcb] InputCommon: fix possible crash with wrong method default value

[b82b8851e4] InputCommon: fix controllers after the first one not defaulting to any default device

[78835f4230] Qt: simplify the preview of control mappings/expressions by removing their device path

and replacing it with a ":" prefix. Also remove white spaces and \n \t \r.

bugfix: fix EmulatedController::GetStateLock() not being aquired when reading the expression reference
bugfix: MappingButton::UpdateIndicator() calling State(0) on outputs, breaking ongoing rumbles if a game was running
improvement: also show the state of outputs in the MappingWindow, not just inputs Improvement: make expressions previews appear in Italic if they failed to parse correctly

[0cf6535d51] InputCommon: make OutputerReference::GetStateInternal() return the last cached value

also make the m_cached_states array use atomic variables, for the same reason.

[5bba177a05] Qt: Connect IOWindow::ConfigChanged to Settings::ConfigChanged

[bc703fdc2e] Revert changes moved to other PRs

[dcda0718b9] Improve (and explain) the way wiimote attachments are serialized

[409f7248f9] evdev: revert async devices population as it was broken and unnecessary

It wasn't running because the hotplug thread was waiting on a select and ignoring the repopulation event.
Also made s_devnode_objects 100% thread safe, as it wasn't.

[e7235f97dd] Fix Lint and compilation warnings + build errors

[a966a1f28c] FreeLook: use the new ControllerInterface to get the DeltaTime

[c626bf0ba5] Post merge fixup

[638eeade55] InputCommon: keep setting outputs values even if they have changed if they are != 0

this is because some devices will stop rumbling if we constantly set the same value for some time, and we want to prevent that (yes, it's an extremely rare case)

[8b2dbf9cac] Implement Output "Caching"

Similar to Input Caching, outputs values are now pre-cached and then updated/applied at once. This means we can now mess with output variables reliably, with time based functions and such just like we can for inputs. They could be one input frame "late" compared to before, but the improvements are worth this little unperceivable drawback.

Also reflected changing in the input mappings widgets.

[e0e0de5603] InputCommon: add const to Touch ButtonManager

[d14fa64918] DInput: fix thread safety on static variable. Also added a comment explaining a rare hang.

[2bfe5a54bd] Qt: IOWindow: fix last bugs with devices selection

It wasn't properly updated when suddenly disconnecting a device

[d2ea13ee5d] InputCommon: finalize ControllerInterface safety and stability refactor

-All old devices shared pts are now released immediately (from UI and ControlReference Expressions) when we change the devces list. This fixes a bug where devices could not be recreated because an old version of them still existed as a shared ptr. This also means we basically don't really have any relevant reason to keep devices as shared ptrs, but it's also NOT a problem anymore. -A lot of platforms now populate asyncronously, without stalling the main thread. -Qt UI "Refresh Devices" button doesn't stop the CPU thread anymore (it's not necessary anymore) -Fixes add/remove order of devices population, and rare cases where devices could be added twice or be missing -Prevent devices from being added before the first population (RefreshDevices()), it was literally pointless as they would have been cleaned anyway. -Implemented a quick DevicesRefresh() which only recreates some devices if only the render widget had changed (workaround for issue 11702 and 12478). -Avoid broadcasting DevicesChanged() callbacks when there were no changes. -Avoid refreshing devices on shutdown.
-Small fixes/polish, improve thread safety
-Removed window from OSX backend as it wasn't used -Improved code to handle long waits for events that might not come (to fix the hangs)

[fa0dcd2310] Qt: add a way of asking whether we are the host/main thread

[ba71b699c2] Comments improvements and removed useless includes

[ef5e98757d] InputCommon: make wiimote rumble var atomic for safety

[0e3c4f0e42] InputCommon: remove relative absolute time setting

It's not needed anymore as there are input functions to achieve the same result now.
Also fixed autohid, which I had broken, and polshed it a bit. Removed custom time calculation and replaced it with emulation speed.

[b868a7f10c] InputCommon: remove pragma optimize off

[a2ede1f316] Qt: restore calibration error to a higher value

[7c8c13307c] Qt: cleaning ToolTip code

[7b765b6d85] InputCommon: add reset to timer function, add accumulate to pulse function

[7c5d21cc2f] InputCommon: better define the difference between smooth() and relative() input funcs

renamed relative() to sharedRelative(). smooth() can also be called toRelative() now.

[646b89ad73] Qt: restore ability to disable quotes on input expression detection

also make the expression type enum clearer and less hacky

[07a820271f] Qt: fix build error

[309262aaf7] InputCommon: fix Xinput2 build errors

[b31ae281e4] Qt: User/expression variables naming consistency

[65c76ecdb3] InputCommon: forgot to put back a timer reinitialization in DSU

[d0d8545896] UDP: fix client ID being different betweent between every pad request

This isn't following the official documentation which says: "Client or server ID who sent this packet. Should stay the same on one run. Can be randomly generated on startup"

[db25df9626] Qt: fix IOWindows keeping a device shared pointer and destroying it unsafely

The devices lock needs to be acquired when destroying devices (which in this case was kept alive), otherwise other threads might cuncurrently r/w the same variables. For example s_guids_in_use in DInputJoystick.cpp

[9adbd0ef30] InputCommon: move some comments that were on the right of code

[e144ac6294] InputCommon: Fix IOWindow not reacting to devices change correctly

[8abc354e30] Qt: cleaning up code to expose user/expression variables to mappings UI

[bd33eedfc7] Qt: QComboBoxWithMouseWheelDisabled comment

[d578182ddf] InputCommon: block on DSU servers collectively instead of individually

imported PR 9558 with iwubcode permission,
and applied my improvements on top.

[a0ffa1b645] InputCommon: remove "IgnoreFocus" flag on VariableExpression

It was wrong and you can achieve the same with the ignoreFocus() func when necessary

[c67fee5346] InputCommon: finished (get)gameSpeed control expression

[5687fc196a] Qt: fix IOWindow not listening to config changed events (it's very unlikely to happen, if not impossible anyway)

[c9d5805f97] Expose Control Expression "user" variables to mappings UI

-add a way to reset their value (from the mappings UI) -fix "memory leak" where they would never be cleaned, one would be created every time you wrote a character -"fix" ability to create variables with an empty string by just writing "$"

[8f1e38a2d9] Fix FPS counter and Game Window speed % breaking on pause/unpause

-Add pause state to FPSCounter.
-Add ability to have more than one "OnStateChanged" callback in core. -Add GetActualEmulationSpeed() to Core. Returns 1 by default. It will be used by future PRs.

[7fd8b7d77a] InputCommon: implement restoring of outputs on unpause

[a4fbedc034] InputCommon: improve "hasFocus" input expression

[f6b46ac2b3] InputCommon: fix configs reload after opening an input panel breaking ControlReferences values

[1d1c526664] InputCommon: finish relativeToSpeed(input) input function

[56a2f2b8ee] InputCommon: revert some inputs automatically ignoring focus

it's not necessary anymore

[2741f8fa5e] ControllerInterface: fix devices mutex not unlocking before invoking devices changed callback

[654a487cf8] InputCommon: small controller interface fixes

[35d2278cdf] Fix relevant Lint warnings

[e7141bfea4] Fix build errors

[320f9411bd] A bunch of comments and irrelevant changes

[3ffef9a828] InputCommon: explain problems with "expression vars" and fix a crash with them

Also explain why we can't use inputs in output expressions or outputs in input expressions

[8d2f5cdf4b] InputCommon: implement some kind of output caching

Different from input caching, as outputs are still updated (re-applied) immediately when their values change, but they now have one value per input channel, and they remember it, so it can persist if the devices change.

[e45e178e56] InputCommon: implement devices outputs mutex to avoid cuncurrent writing on them

[b5c92a8a20] InputCommon: fix ControllerInterface::SetChannelRunning() changing the input channel (it shouldn't)

[c592984d0e] InputCommon: forgotten to make some methods private

[00b9bf3650] Core: improved input channel starting/pausing calls

Also removed the old way to clear the GC rumble, which isn't needed anymore and was kind of hacky anyway because it didn't reset wiimote rumble

[e6ea701f6b] Qt: avoid MappingButton(s) highlighting when a IOWindow is open as they could show a wrong state

[d9dec4b111] InputCommon: make cursor use the new ControllerInterface channel DT, to be more accurate

[e1a113f8d6] InputCommon: remove unneded atomics, they are already thread safe now

[ef4afe6942] InputCommon: avoid cleaning and repopulating devices on window change (on Windows only)

Might help issue https://bugs.dolphin-emu.org/issues/11702

[f9b57b9ca9] InputCommon: added code to start/stop input channels to reset their outputs and relative inputs

[c523c21984] Qt: Fix IOWindows not applying changes to the range until you clicked OK

[240726447e] Qt: added button to test output on directly on an individual device output

Also fixed some const correctness and improved some comments

[f2278c32ea] InputCommon: revert wiimote cursor to two states because the new design didn't work out

[76a90d2c8d] Qt: revert bad changes to wiimote extension combo box

[acc77208da] InputCommon: just some comments

[9d3c71ff1f] InputCommon: const correctness on GetState() functions.

Also fixed some names not following coding standards.

[9c5e319ddd] Qt: fix dolphin not caching input when the emulation was started but paused

[e63608e290] Qt: reverted unnecessary and wrong change

[a6f9237a55] Qt: MappingIndicator: remove "useless" calibration error threshold which only made it confusing

[1d027fa07d] InputCommon: fixed outputs internal state accumulation

[b852f2fdcf] Qt: remove TODO comments that have been fixed by other means

[adbff7041b] FreeLook: remove recently added state lock, which isn't necessary anymore.

Also avoid caching input unless it's active.

[db91938d5f] Hotkeys: remove useless attempt at making input update frequency more accurate

[32c5e9aeda] InputCommon: fix small bug which could prevent a DInput Joystick device from being added

If the device first attempted creation without a window handle, which means it couldn't obtain exclusive mode, which implies it would have not outputs, it would not be created as a device if it also had no valid inputs, but it would be added to the list of GUIDs in use. If we then re-populated devices with a valid window handle, this device could never be actually recreated, even if it now had some outputs.

[5490b59e58] InputCommon: keep DirectInput8 interface alive

[fb478656c6] InputCommon: new KeyboardMouse logs and random attempt to fix bug 11702

[c06d096527] InputCommon: add some error logs to Windows KeyboardMouse device

[f8f93be892] Small fixes

[514824dc12] Common: Fix (new) ControllerInterface log order

[9e32990ba5] Post rebase fixup

[a72218882b] //To dos around the code

[176c60d60d] small threading fix

[8211f8c58c] InputCommon: add devices sorting order

This is to make sure the MouseAndKeyboard (Windows) device is always added first, effectively making it the "default" default device (index 0), otherwise, with the recent changes, which allowed it to be added async, it could end up in any place in the list. Also make hotplug devices like DSU and Wiimote appear at the end of the list.

[cb1cab2cf2] InputCommon: improve UDP Client devices disconnection checks

[35082bbb7c] WiimoteReal: make devices population "more" thread safe

[4585b28c86] Fix mising "m_"

[5a8ec296e3] InputCommon: make ControllerInterface devices population completely thread safe.

InputCommon: fix multiple problems with UDP Client

[e40cf8e7be] InputCommon: add a new thread safety check to avoid cuncurrent (or useless) PopulateDevices() calls

[4224c8a0a7] InputCommon: restore accidentally deleted include

[b9d4409f48] Qt: Remove useless/old ConfigChanged() from UDP Widget

[b805e72479] InputCommon: fix build

[d0a85724f7] InputCommon: fix some build errors

[f66db5da03] InputCommon: fix includes

[826a13206f] Qt: automatically apply word wrap to function expressions

[34fe5f59fe] InputCommon: fix some compilation and Lint warnings

[da74347762] InputCommon: moved relative axis conversion to "rate of change" into a function expression

See: "relativeToSpeed(input)".
Also added a real world elapsed time between input polls, so that function expressions can do whatever they want with it.
A few other fixes around.

[e74d699b8e] InputCommon: implement actual relative axis mouse in XInput2

[85962165dd] Core: fix SI poll delta time counter

InputCommon: add function expression to turn a relative axis into a rate of change/speed
InputCommon: finish gameToInputFrames and timeToInputFrames function expressions

[c062d4d3ad] InputCommon: Change Outputs to use the sum and not max of their states

[498f4fbaae] InputCommon: finishing some new input expressions

[fe867915d9] First version

[0c106a1695] InputCommon: restore wiimote cursor clamping

[e24fa04730] InputCommon: misc review fixes

[4430aac028] Input Expressions and Input Widgets

Input Function Expressions:
-Added a lot of new function expressions: mostly to remap a mouse to an analog stick,
  especially useful for FPS GC games (some more functions will come with later PRs,
  and this will be even more useful after I submit the new relative input code)
  (these functions are "AntiDeadZone", "BezierCurve", "AntiAcceleration", ...
  which all try to contrast the adjustments the game makes to a strick input)
  (merge is more messy than it needs
  to because someone added similar functions to me recently).
-Fixed some < being switched for <= in some function expressions,
  causing wrong/inconsistent comparisors.
-Cleaned up some other broken input expression code.

Improved the IOWindow:
-Added tooltip and made the range selection much clearer. -Functions are now listed by category (Logic/Math, State/time based, stick helpers,
  and then "meta" which are incoming in a later PR).
-Adding a function from the list now adds its default parameter names to the list already,
  so you know how to use it.
-Hidden range from input settings (because it wouldn't even be serialized in our config). -Fixed range being saved even if we didn't click "OK". -Added the text "[default] " in front of the default device, to make it clearer to users on
  which one it is (it is set from the parent widget, not this one).
-Fixed device keys not appearing if the default device wasn't connected
  (bug https://bugs.dolphin-emu.org/issues/12325).

[315d418ed6] InputCommon: wiimote cursor fixes

-Fix wiimote cursor having a single state between game and UI,
  which moved it in the game while its customization widget had focus even if
  Dolphin was set to ignore background input.
-Fix wiimote cursor max speed being clamp to 1 for no reason
  (if you mapped it to a mouse and moved it too fast, it just wouldn't...)
-Add a setting to move the wiimote cursor independently of the game speed,
  so that if it's based on a relative axis, like the mouse, its movement speed doesn't depend on the emulation speed.
-Fix wiimote cursor state not being reset when needed.

[054f7e0c0e] Qt: Improvement to NumericSettings<T> widgets

-Added UI edit conditions to (Input)NumericSettings. -Added UI tooltip to (Input)NumericSettings (it wasn't shown before).

[d8fcb342a3] InputCommon: restore custom range support for modifiers

and any other control. Also remove all the hacks around it (before it would break when the input configs where reset to default, but we now have a custom default value for the range)

[485dcd9575] Qt: Fix "Enable" button in MappingWidgets

It was not disabling all the nested widgets (you can test this by going to WiiMote->MotionInput->Point->Enable and setting it off, the "Total Yaw" widget will remain enabled because it was "nested")

[ad0c21a2ca] Qt: MappingWidget improvements

-Added tooltip to MappingWIdget.
-Increased frequency of UI updates of mapping widgets from 30 to 60 (which is now in line with their actual internal update frequency)

[e01c9ad72e] Qt: Improvements to MappingWindow

-Added tooltip to explain what the default device is. -Fixed default device being none while the user thinking it was the selected one (on the first configuration). -Made it cleared to users which one is the default device. -Hidden useless tab on top