### PR TITLE
Simplify verification URL to avoid issues with Git backend changes

### DIFF
--- a/Source/Core/DolphinQt/MarioPartyNetplay/DownloadWorker.cpp
+++ b/Source/Core/DolphinQt/MarioPartyNetplay/DownloadWorker.cpp
@@ -35,7 +35,7 @@ void DownloadWorker::startDownload()
 
     // Check if the final URL is the expected GitHub objects CDN
     std::string final_url = httpRequest.GetFinalUrl();
-    if (final_url.find("objects.githubusercontent.com") == std::string::npos) {
+    if (final_url.find("githubusercontent.com") == std::string::npos) {
         emit errorOccurred(QStringLiteral("Did not reach the expected GitHub objects URL. Final URL: %1").arg(QString::fromStdString(final_url)));
         return;
     }


### PR DESCRIPTION
GitHub now seems to use both objects.githubusercontent.com and release-assets.githubusercontent.com for release binaries, which causes errors with the updater. Removing the subdomain from the verification check fixes the updater.